### PR TITLE
Partial compatability with rustc 1.56

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ fn opts() -> Opts {
 
 fn main() {
     let opts = opts();
-    println!("Options: {opts:?}");
+    println!("Options: {:?}", opts);
 }
 ```
 

--- a/bpaf_derive/src/field.rs
+++ b/bpaf_derive/src/field.rs
@@ -135,7 +135,7 @@ impl FieldParser {
         let name = &self.name;
         match name {
             Some(name) => name.clone(),
-            None => Ident::new(&format!("f{ix}"), Span::call_site()),
+            None => Ident::new(&format!("f{}", ix), Span::call_site()),
         }
     }
 }
@@ -171,7 +171,7 @@ impl<T: Parse> Parse for FieldAttrs<T> {
             comma(input)?;
         }
         if !input.is_empty() {
-            return Err(input.error(format!("Can't parse remaining attributes: {input}")));
+            return Err(input.error(format!("Can't parse remaining attributes: {}", input)));
         }
 
         Ok(FieldAttrs {

--- a/bpaf_derive/src/top.rs
+++ b/bpaf_derive/src/top.rs
@@ -498,7 +498,7 @@ impl ToTokens for BParser {
                 if xs.len() == 1 {
                     xs[0].to_tokens(tokens);
                 } else {
-                    let mk = |i| Ident::new(&format!("alt{i}"), Span::call_site());
+                    let mk = |i| Ident::new(&format!("alt{}", i), Span::call_site());
                     let names = xs.iter().enumerate().map(|(ix, _)| mk(ix));
                     let parse_decls = xs.iter().enumerate().map(|(ix, parser)| {
                         let name = mk(ix);

--- a/examples/derive_show_asm.rs
+++ b/examples/derive_show_asm.rs
@@ -138,7 +138,7 @@ impl std::fmt::Display for Focus {
             Focus::Test(t) => write!(f, "--test {}", t),
             Focus::Bench(b) => write!(f, "--bench {}", b),
             Focus::Example(e) => write!(f, "--example {}", e),
-            Focus::Bin(b) => write!(f, "--bin {b}"),
+            Focus::Bin(b) => write!(f, "--bin {}", b),
         }
     }
 }

--- a/examples/negative.rs
+++ b/examples/negative.rs
@@ -11,5 +11,5 @@ This will transform everything after '--' into non flags, '--age' will handle '-
 and positional handlers will be able to handle the rest.
     --age -- -1";
     let num = Info::default().descr(msg).for_parser(age).run();
-    println!("age: {num}");
+    println!("age: {}", num);
 }

--- a/examples/positional.rs
+++ b/examples/positional.rs
@@ -19,5 +19,5 @@ fn main() {
 
     let opts = Info::default().for_parser(parser).run();
 
-    println!("{opts:#?}");
+    println!("{:#?}", opts);
 }

--- a/examples/positional_derive.rs
+++ b/examples/positional_derive.rs
@@ -14,5 +14,5 @@ struct Options {
 
 fn main() {
     let opts = options().run();
-    println!("{opts:#?}");
+    println!("{:#?}", opts);
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,5 +29,5 @@ fn opts() -> Opts {
 
 fn main() {
     let opts = opts();
-    println!("Options: {opts:?}");
+    println!("Options: {:?}", opts);
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -242,10 +242,10 @@ impl Args {
             Some((ix, Arg::Word(w))) => (ix, w),
             Some((_ix, flag)) => {
                 return Err(Error::Stderr(format!(
-                    "{arg} requires an argument, got flag {flag}"
+                    "{} requires an argument, got flag {}", arg, flag
                 )))
             }
-            _ => return Err(Error::Stderr(format!("{arg} requires an argument"))),
+            _ => return Err(Error::Stderr(format!("{} requires an argument", arg))),
         };
         let val = val.clone();
         self.current = Some(val.clone());
@@ -266,7 +266,7 @@ impl Args {
                 self.remove(ix);
                 Ok(Some(w))
             }
-            Some((_, arg)) => Err(Error::Stderr(format!("Expected an argument, got {arg}"))),
+            Some((_, arg)) => Err(Error::Stderr(format!("Expected an argument, got {}", arg))),
             None => Ok(None),
         }
     }

--- a/src/info.rs
+++ b/src/info.rs
@@ -661,7 +661,7 @@ impl Info {
                     return Err(Error::Stdout(msg));
                 }
                 Ok((ExtraParams::Version(v), _)) => {
-                    return Err(Error::Stdout(format!("Version: {v}")));
+                    return Err(Error::Stdout(format!("Version: {}", v)));
                 }
                 Err(_) => {}
             }


### PR DESCRIPTION
I'm still using and older rustc which does not support this new `format` syntax. This MR replaces the usages of that syntax to the traditional format with arguments.

It's called partial support because tests don't build because of some derive macro incompatability. The offending test is `help_with_default_parse`, and if I remove it all tests pass.