### PR TITLE
Remove old references to argument_os

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,13 +774,12 @@ use std::str::FromStr;
 ///     // `bpaf_derive` inserts implicit `argument`, `optional` and the right type
 ///     number_3: Option<u32>,
 ///
-///     // fails to compile: you need to specify a consumer, `argument` or `argument_os`
+///     // fails to compile: you need to specify `argument`
 ///     // #[bpaf(optional)]
-///     // number_4: Option<u32>
+///     // number_4: Option<u32>,
 ///
-///     // fails to compile: you also need to specify how to go from String to u32
-///     // #[bpaf(argument("N"), optional)]
-///     // number_5: Option<u32>,
+///     #[bpaf(argument("N"), optional)]
+///     number_5: Option<u32>,
 ///
 ///     // explicit consumer and a full postprocessing chain
 ///     #[bpaf(argument::<u32>("N"), optional)]
@@ -1170,8 +1169,7 @@ pub trait Parser<T> {
     ///
     /// Allows to generate autocompletion information for shell. Completer places generated input
     /// in place of metavar placeholders, so running `completer` on something that doesn't have a
-    /// [`positional`] or an [`argument`](NamedArg::argument) (or their `_os` variants) doesn't make
-    /// much sense.
+    /// [`positional`] or an [`argument`](NamedArg::argument) doesn't make much sense.
     ///
     /// Takes a function as a parameter that tries to complete partial input to a full one with
     /// optional description. `bpaf` would substitute current positional item or an argument an empty

--- a/src/meta_usage.rs
+++ b/src/meta_usage.rs
@@ -58,7 +58,7 @@ fn collect_usage_meta(meta: &Meta, is_pos: &mut bool) -> Option<UsageMeta> {
                     assert!(!*is_pos || this_pos,
                         "bpaf usage BUG: all positional and command items must be placed in the right \
                         most position of the structure or tuple they are in but {} breaks this rule. \
-                        See bpaf documentation for `positional` and `positional_os` for details.",
+                        See bpaf documentation for `positional` for details.",
                         usage_meta
                     );
                     *is_pos |= this_pos;


### PR DESCRIPTION
Removed a couple remaining references to `argument_os`. Additionally, I uncommented `number_5` in the example in the [Derive specific considerations](https://docs.rs/bpaf/0.7.1/bpaf/trait.Parser.html#derive-specific-considerations) section in the docs for `Parser` because it does compile now.