### PR TITLE
Evaluate zsh shell complete function if given

### DIFF
--- a/src/complete_run.rs
+++ b/src/complete_run.rs
@@ -121,7 +121,7 @@ for line in \"${{(@)lines}}\" ; do
 
         compadd ${{cmd[@]}} -- $table[literal]
     elif [[ \"${{parts[1]}}\" == \"zsh\" ]] ; then
-        ${{parts[2]}}
+        eval ${{parts[2]}}
     else
         compadd -- \"${{parts[1]}}\"
     fi


### PR DESCRIPTION
So there might be something I'm getting very wrong here:

I have a subcommand which passes through to a separate program with its own completer for bash and zsh.

the only way to get this working with bash was by the means of `source PATH_TO_COMPLETER; _subcommand_bash_completion`, because the completion adapter just executes this as an `eval`:

```rust
fn complete_subcommand_shell() -> bpaf::ShellComp {
    bpaf::ShellComp::Raw {
        
		bash: Box::leak(
            format!(
                "source {}; _subcommand_bash_completion",
                env!("subcommand_BASH_COMPLETION_SCRIPT")
            )
            .into_boxed_str(),
        ),
        
		zsh: ""
		fish: "",
        elvish: "",
    }
}
```


trying to do the same with zsh however fails with

```
_myprogram:33: no such file or directory: source <PATH_TO_COMPLETER..>; _subcommand
```

unless i add an eval at the same position we have it in the bash adapter.

executing the script directly, seems to happen outside of the zsh completion mode as `$words` and `compadd` are undefined.

including the script directly runs into issues with linebreaks:


```
\ \ \ \ \#\ FIXME:\ This\ doesn\'t\ work\ properly\ if\ the\ suggestion\ word\ contains\ a\ \`:\`     \ \ IFS=\"\$ifs_bk\"                                                                                  \ \ for\ suggestion\ in\ \$\{res:1\}\;\ do                                                            \ \ local\ tpe=\"\$\{\$\{res\[1\]\}%%\>                                                             
\ \ \ \ \#\ itself                                                                                    \ \ IFS=\$\'$'\n'\'                                                                                   \ \ if\ \[\[\ \"\$tpe\"\ ==\ filenames\ \]\]\;\ then                                                  _subcommand                                                                                                
\ \ \ \ compadd\ -f                                                                                   \ \ _describe\ \'subcommand\'\ suggestions                                                                   \ \ local\ -a\ suggestions                                                                            function\ _subcommand\(\)\ \{                                                                              
\ \ \ \ suggestions+=\"\$\{suggestion/                                                                \ \ declare\ -a\ suggestions                                                                          \ \ local\ ifs_bk=\"\$IFS\"                                                                           \}                                                                                                  
\ \ \#\ echo\ \$CURRENT                                                                               \ \ done                                                                                              \ \ local\ input=\(\"\$\{\(Q\)words\[@\]:1\}\"\)                                                                                                                                                          
\ \ \#\ echo\ \$input                                                                                 \ \ fi                                                                                                \ \ local\ res=\(\$\(GET_COMPLETIONS=\$\(\(CURRENT\ -\ 2\)\)\ \"\$input\[@\]\"\ 2\>/dev/null\)\)                                            

```


So this PR adds the `eval` to zsh completions - it might not be the right way but it was the only that led to success for me