### PR TITLE
fix: show more suggestions

### DIFF
--- a/src/meta_youmean.rs
+++ b/src/meta_youmean.rs
@@ -13,7 +13,7 @@ pub(crate) fn should_suggest(err: &Error) -> bool {
             for x in xs.iter() {
                 hi.classify_item(x);
             }
-            hi.flgs.is_empty() && hi.psns.is_empty()
+            hi.psns.is_empty()
         }
     }
 }


### PR DESCRIPTION
reg https://github.com/pacak/bpaf/issues/154

I don't quite get why `should_suggest` requires `flgs` to be empty - in fact if there are flags it should indeed suggest is my opinion.

This change makes the error message more correct in most cases i came across.

It's still not perfect, the suggestions are not filtered by what is already given.

like in my example in https://github.com/pacak/bpaf/issues/154:

```
$ notgit log --oneline --doesnotexist
No such flag: `--doesnotexist`, did you mean `--oneline`?
```

Though it does also honor `hide()` correctly.
