### PR TITLE
Semantic documentation generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ exclude = [".github/workflows", "tarp.sh"]
 [dependencies]
 bpaf_derive = { path = "./bpaf_derive", version = "=0.3.5", optional = true }
 owo-colors = { version = "3.5.0", features = ["supports-colors"], optional = true }
-#roff = { path = "../roff-rs", version = "0.2.1", optional = true }
-roff = { git = "https://github.com/pacak/semantic", branch = "semantic", optional = true }
+roff = { path = "../roff-rs", version = "0.2.1", optional = true }
+#roff = { git = "https://github.com/pacak/semantic", branch = "semantic", optional = true }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ exclude = [".github/workflows", "tarp.sh"]
 [dependencies]
 bpaf_derive = { path = "./bpaf_derive", version = "=0.3.5", optional = true }
 owo-colors = { version = "3.5.0", features = ["supports-colors"], optional = true }
-roff = { path = "../roff-rs", version = "0.2.1", optional = true }
-#roff = { git = "https://github.com/pacak/semantic", branch = "semantic", optional = true }
+roff = { git = "https://github.com/pacak/semantic", branch = "semantic", optional = true }
+#roff = { path = "../roff-rs", version = "0.2.1", optional = true }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ exclude = [".github/workflows", "tarp.sh"]
 [dependencies]
 bpaf_derive = { path = "./bpaf_derive", version = "=0.3.5", optional = true }
 owo-colors = { version = "3.5.0", features = ["supports-colors"], optional = true }
-roff = { version = "0.2.1", optional = true }
+#roff = { path = "../roff-rs", version = "0.2.1", optional = true }
+roff = { git = "https://github.com/pacak/semantic", branch = "semantic", optional = true }
+
 
 [dev-dependencies]
 bpaf = { path = ".",  features = ["derive", "extradocs", "autocomplete", "manpage"] }

--- a/src/_applicative.rs
+++ b/src/_applicative.rs
@@ -146,6 +146,9 @@
 //! `bpaf` needs to check items past the first failure point to collect all the possible
 //! completions.
 
+// unit of composition is a single parser
+// add a new abstraction layer, get addition instead of multiplication
+
 //! ## Alternative Functors
 //!
 //! So far `Applicative Functors` allow us to create structs containing multiple fields out of

--- a/src/docugen.rs
+++ b/src/docugen.rs
@@ -1,12 +1,284 @@
+//! # Documentation generation
+//!
+//! You start by running [`collect_help_info`] or [`collect_parser_help_info`] depending if you
+//! want to generate documentation for the whole parser or for a fragmet of it. From
+//! there you can either rely in bpaf to generate the whole documentation for you or to
+//! [`split`](HelpInfo::split) [`HelpInfo`] into smaller bits and compose them with extra text.
+//!
+//! ```rust
+//! # use bpaf::*;
+//! # use std::path::PathBuf;
+//! #[derive(Debug, Clone, Bpaf)]
+//! #[bpaf(options)]
+//! /// List directory contents
+//! ///
+//! ///
+//! /// List information about the FILEs (the current directory by default).
+//! /// Prints name only unless `--long` is specified
+//! ///
+//! ///     Exit status:
+//! ///       0: if OK
+//! ///       1: if requested FILEs does not exist
+//! struct Options {
+//!     /// use a long listing format
+//!     #[bpaf(short, long)]
+//!     long: bool,
+//!     /// use specific paths instead of current directory
+//!     #[bpaf(positional("FILE"))]
+//!     files: Vec<PathBuf>
+//! }
+//!
+//! use bpaf::docugen::{
+//!     collect_help_info,
+//!     roff::semantic::Semantic,
+//!     roff::write_updated,
+//!     roff::man::{Manpage, Section},
+//! };
+//!
+//! // generate semantic document
+//! let mut doc = Semantic::default();
+//! doc += collect_help_info(options(), "ls");
+//!
+//! // render to markdown and save to file
+//! let markdown = doc.render_to_markdown();
+//! # let path = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("tests").join("sample.md");
+//! # let mut files_updated =
+//! write_updated(path, markdown.as_bytes()).unwrap();
+//!
+//! // render to groff and save to file
+//! let man = Manpage::new("ls", Section::General,
+//!     &["1 Jan 2023", "rust toolbox", "File lister 2000"]);
+//! let groff = doc.render_to_manpage(man);
+//! # let path = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("tests").join("sample.1");
+//! # files_updated |=
+//! write_updated(path, groff.as_bytes()).unwrap();
+//! # assert!(!files_updated, "Generated docs are updated, commit the files");
+//! ```
+//!<details>
+//!<summary>Generated markdown</summary>
+//!
+//!```markdown
+#![doc = include_str!("../tests/sample.md")]
+//!```
+//!
+//!</details>
+//!
+//!<details>
+//!<summary>Rendered markdown</summary>
+//!
+#![doc = include_str!("../tests/sample.md")]
+//!
+//!</details>
+//!
+//!<details>
+//!<summary>Generated ROFF</summary>
+//!
+//!```text
+#![doc = include_str!("../tests/sample.1")]
+//!```
+//!
+//!</details>
+
 use crate::{
+    info::Info,
     item::ShortLong,
     meta_help::{HelpItem, HelpItems},
     meta_usage::UsageMeta,
     *,
 };
-pub use roff::man::Section;
+pub use roff;
 pub use roff::semantic::*;
-pub use roff::write_updated;
+
+/// Help information collected off a parser
+///
+/// You can create this from [`OptionParser`]
+#[derive(Debug, Clone)]
+pub struct HelpInfo {
+    meta: Meta,
+    info: Option<Info>,
+    name: Option<&'static str>,
+}
+
+impl SemWrite for HelpInfo {
+    fn sem_write(self, to: &mut Semantic) {
+        if let Some(t) = self.info.as_ref().and_then(|i| i.descr) {
+            match self.name {
+                Some(name) => {
+                    to.section("Name");
+                    to.paragraph([mono(name), text(" - "), text(t)]);
+                }
+                None => {
+                    to.section("Summary");
+                    to.paragraph(text(t));
+                }
+            }
+        }
+
+        if let Some(t) = self.info.as_ref().and_then(|i| i.header) {
+            to.section("Description");
+            to.paragraph(text(t));
+        }
+
+        *to += self.split();
+
+        if let Some(t) = self.info.as_ref().and_then(|i| i.footer) {
+            to.paragraph(text(t));
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// A set of help items
+///
+/// Designed mostly to be a named type with [`SemWrite`] implementation
+pub struct Items<'a>(Vec<HelpItem<'a>>);
+
+impl<'a> Items<'a> {
+    /// Returns `true` if there's items inside.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns number of elements inside.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// [`HelpInfo`] [`split`](HelpInfo::split) into flags, positional items and commands
+#[derive(Debug, Clone)]
+pub struct UsageItems<'a> {
+    /// Collection of all the flags (`--flag`)
+    pub flags: Items<'a>,
+    /// Collection of all the positional items (`<FILE>`)
+    pub positionals: Items<'a>,
+    /// Collection of all the commands (`build`)
+    pub commands: Items<'a>,
+}
+
+impl SemWrite for Items<'_> {
+    fn sem_write(self, to: &mut Semantic) {
+        to.definition_list(self.0);
+    }
+}
+
+pub fn collect_parser_help_info<P, T>(parser: &P) -> HelpInfo
+where
+    P: Parser<T>,
+{
+    HelpInfo {
+        meta: parser.meta(),
+        info: None,
+        name: None,
+    }
+}
+
+pub fn collect_help_info<T>(parser: OptionParser<T>, name: &'static str) -> HelpInfo {
+    HelpInfo {
+        meta: parser.inner.meta(),
+        info: Some(parser.info),
+        name: Some(name),
+    }
+}
+
+pub fn usage<P, T>(parser: &P) -> impl SemWrite + '_
+where
+    P: Parser<T>,
+{
+    collect_parser_help_info(parser)
+    //    write_with(|doc| {
+    //    })
+}
+
+/// Extract and write comma separated flag or command names
+///
+/// Use this if you want to refer to some other parser in parts of your documentation
+pub fn names_only<P, T>(parser: &P) -> impl SemWrite + '_
+where
+    P: Parser<T>,
+{
+    write_with(|doc| {
+        let info = collect_parser_help_info(parser);
+        let items = info.split();
+        for (ix, item) in items
+            .flags
+            .0
+            .iter()
+            .chain(items.positionals.0.iter())
+            .chain(items.commands.0.iter())
+            .enumerate()
+        {
+            if ix > 0 {
+                *doc += text(", ");
+            }
+            match item {
+                HelpItem::Decor { help: _ } | HelpItem::BlankDecor => {}
+                HelpItem::Positional {
+                    strict: _,
+                    metavar,
+                    help: _,
+                } => *doc += *metavar,
+                HelpItem::Command {
+                    name,
+                    short: _,
+                    help: _,
+                    meta: _,
+                    info: _,
+                } => {
+                    *doc += literal(*name);
+                }
+                HelpItem::Flag { name, help: _ } => {
+                    *doc += name.0;
+                }
+                HelpItem::Argument {
+                    name,
+                    metavar,
+                    env: _,
+                    help: _,
+                } => {
+                    *doc += name.0;
+                    *doc += mono(" ");
+                    *doc += *metavar;
+                }
+            }
+        }
+    })
+}
+
+impl HelpInfo {
+    /// Split [`HelpInfo`] into help info for flags, positionals and commands
+    ///
+    /// You can use this method if you want to customize rendering
+    pub fn split(&self) -> UsageItems {
+        let mut hi = HelpItems::default();
+        hi.classify(&self.meta);
+
+        UsageItems {
+            flags: docugen::Items(hi.flgs),
+            positionals: docugen::Items(hi.psns),
+            commands: docugen::Items(hi.cmds),
+        }
+    }
+}
+
+impl SemWrite for UsageItems<'_> {
+    fn sem_write(self, to: &mut Semantic) {
+        if !self.positionals.is_empty() {
+            to.subsection("Available positional items");
+            *to += self.positionals;
+        }
+
+        if !self.flags.is_empty() {
+            to.subsection("Available options");
+            *to += self.flags;
+        }
+
+        if !self.commands.is_empty() {
+            to.subsection("Available commands");
+            *to += self.commands;
+        }
+    }
+}
 
 impl SemWrite for &UsageMeta {
     fn sem_write(self, to: &mut Semantic) {
@@ -84,21 +356,21 @@ impl SemWrite for meta_help::Metavar {
     }
 }
 
-struct UsageWithHelp<'a>(Vec<HelpItem<'a>>);
-pub struct Usage<'a>(&'a Meta);
 impl SemWrite for HelpItem<'_> {
     fn sem_write(self, to: &mut Semantic) {
         match self {
-            HelpItem::Decor { help } => todo!(),
+            HelpItem::Decor { help } => {
+                to.item(text(help));
+            }
             HelpItem::BlankDecor => {}
             HelpItem::Positional {
                 strict: _,
                 metavar,
                 help,
             } => {
-                *to += Scoped(Block::ListKey, metavar);
+                to.term(metavar);
                 if let Some(help) = help {
-                    *to += Scoped(Block::ListItem, text(help))
+                    to.item(text(help));
                 }
             }
             HelpItem::Command {
@@ -108,22 +380,21 @@ impl SemWrite for HelpItem<'_> {
                 meta: _,
                 info: _,
             } => {
-                if let Some(short) = short {
-                    *to += WithScope(Block::ListKey, |to: &mut Semantic| {
-                        *to += literal(short);
-                        *to += [text(", "), literal(name)]
-                    });
-                } else {
-                    *to += Scoped(Block::ListKey, literal(name));
-                }
+                match short {
+                    Some(short) => to.term(write_with(|to| {
+                        to.text(literal(short)).text([text(", "), literal(name)]);
+                    })),
+                    None => to.term(literal(name)),
+                };
                 if let Some(help) = help {
-                    *to += Scoped(Block::ListItem, text(help));
+                    to.item(text(help));
                 }
             }
+
             HelpItem::Flag { name, help } => {
-                *to += Scoped(Block::ListKey, name.0);
+                to.term(name.0);
                 if let Some(help) = help {
-                    *to += Scoped(Block::ListItem, text(help))
+                    to.item(text(help));
                 }
             }
             HelpItem::Argument {
@@ -132,35 +403,14 @@ impl SemWrite for HelpItem<'_> {
                 env: _,
                 help,
             } => {
-                *to += WithScope(Block::ListKey, |to: &mut Semantic| {
-                    *to += name.0;
-                    *to += mono("=");
-                    *to += metavar;
-                });
+                to.term(write_with(|to| {
+                    to.text(name.0).text(mono("=")).text(metavar);
+                }));
+
                 if let Some(help) = help {
-                    *to += Scoped(Block::ListItem, text(help))
+                    to.item(text(help));
                 }
             }
         }
-    }
-}
-
-impl SemWrite for UsageWithHelp<'_> {
-    fn sem_write(self, to: &mut Semantic) {
-        *to += Scoped(Block::DefinitionList, self.0);
-    }
-}
-impl Meta {
-    pub fn as_usage(&self) -> Usage {
-        Usage(self)
-    }
-}
-
-impl SemWrite for Usage<'_> {
-    fn sem_write(self, to: &mut Semantic) {
-        let mut hi = HelpItems::default();
-        hi.classify(self.0);
-
-        *to += UsageWithHelp(hi.flgs)
     }
 }

--- a/src/docugen.rs
+++ b/src/docugen.rs
@@ -98,7 +98,7 @@ impl Write for HelpInfo {
             match self.name {
                 Some(name) => {
                     to.section("Name");
-                    to.paragraph(&[mono(name), text(" - "), text(t)]);
+                    to.paragraph([mono(name), text(" - "), text(t)]);
                 }
                 None => {
                     to.section("Summary");
@@ -112,7 +112,7 @@ impl Write for HelpInfo {
             to.paragraph(text(t));
         }
 
-        to.push(self.split());
+        to.push(&self.split());
 
         if let Some(t) = self.info.as_ref().and_then(|i| i.footer) {
             to.paragraph(text(t));
@@ -185,7 +185,7 @@ pub fn collect_help_info<T>(parser: OptionParser<T>, name: &'static str) -> Help
 pub fn synopsis<T>(parser: &OptionParser<T>) -> impl Write + '_ {
     |doc: &mut Doc| {
         if let Some(meta) = parser.inner.meta().to_usage_meta() {
-            doc.push(meta);
+            doc.push(&meta);
         } else {
             doc.text("Parser takes no parameters");
         }
@@ -239,7 +239,7 @@ where
                     prefix.write(doc);
                 }
                 if let Some(usage) = meta.to_usage_meta() {
-                    doc.literal(name).mono(" ").push(usage);
+                    doc.literal(name).mono(" ").push(&usage);
                 } else {
                     doc.literal(name);
                 }
@@ -254,7 +254,7 @@ where
                 doc.paragraph(header);
             }
 
-            doc.push(HelpInfo {
+            doc.push(&HelpInfo {
                 meta: meta.clone(),
                 info: None,
                 name: None,
@@ -360,9 +360,9 @@ where
         for (ix, item) in items
             .flags
             .0
-            .into_iter()
-            .chain(items.positionals.0.into_iter())
-            .chain(items.commands.0.into_iter())
+            .iter()
+            .chain(items.positionals.0.iter())
+            .chain(items.commands.0.iter())
             .enumerate()
         {
             if ix > 0 {
@@ -387,7 +387,7 @@ where
                     doc.literal(name);
                 }
                 HelpItem::Flag { name, help: _ } => {
-                    doc.push(name.0);
+                    doc.push(&name.0);
                 }
                 HelpItem::Argument {
                     name,
@@ -395,7 +395,7 @@ where
                     env: _,
                     help: _,
                 } => {
-                    doc.push(name.0).mono(" ").push(metavar);
+                    doc.push(&name.0).mono(" ").push(metavar);
                 }
             }
         }
@@ -574,7 +574,7 @@ impl Write for HelpItem<'_> {
             } => {
                 match short {
                     Some(short) => to.term(|to: &mut Doc| {
-                        to.push(StyledChar(Style::Literal, *short))
+                        to.push(&StyledChar(Style::Literal, *short))
                             .text(", ")
                             .literal(name);
                     }),
@@ -599,7 +599,7 @@ impl Write for HelpItem<'_> {
                 help,
             } => {
                 to.term(|to: &mut Doc| {
-                    to.push(name.0).push(mono("=")).push(*metavar);
+                    to.push(&name.0).push(&mono("=")).push(metavar);
                 });
 
                 if let Some(help) = help {

--- a/src/docugen.rs
+++ b/src/docugen.rs
@@ -1,0 +1,166 @@
+use crate::{
+    item::ShortLong,
+    meta_help::{HelpItem, HelpItems},
+    meta_usage::UsageMeta,
+    *,
+};
+pub use roff::man::Section;
+pub use roff::semantic::*;
+pub use roff::write_updated;
+
+impl SemWrite for &UsageMeta {
+    fn sem_write(self, to: &mut Semantic) {
+        match self {
+            UsageMeta::And(xs) => {
+                for (ix, x) in xs.iter().enumerate() {
+                    if ix != 0 {
+                        *to += mono(" ");
+                    }
+                    x.sem_write(to);
+                }
+            }
+            UsageMeta::Or(xs) => {
+                for (ix, x) in xs.iter().enumerate() {
+                    if ix != 0 {
+                        *to += mono(" | ");
+                    }
+                    x.sem_write(to);
+                }
+            }
+            UsageMeta::Required(req) => {
+                *to += mono("(");
+                req.sem_write(to);
+                *to += mono(")");
+            }
+            UsageMeta::Optional(opt) => {
+                *to += mono("[");
+                opt.sem_write(to);
+                *to += mono("]");
+            }
+            UsageMeta::Many(_) => todo!(),
+            UsageMeta::ShortFlag(f) => {
+                *to += [literal('-'), literal(*f)];
+            }
+            UsageMeta::ShortArg(f, m) => {
+                *to += [literal('-'), literal(*f), mono('=')];
+                *to += metavar(*m);
+            }
+            UsageMeta::LongFlag(f) => {
+                *to += [literal("--"), literal(*f)];
+            }
+            UsageMeta::LongArg(f, m) => {
+                *to += [literal("--"), literal(*f), mono("="), metavar(m)];
+            }
+            UsageMeta::Pos(m) => {
+                *to += metavar(*m);
+            }
+            UsageMeta::StrictPos(m) => {
+                *to += [mono("-- "), metavar(*m)];
+            }
+
+            UsageMeta::Command => {
+                *to += [literal("COMMAND"), mono(" "), metavar("...")];
+            }
+        }
+    }
+}
+
+impl SemWrite for ShortLong {
+    fn sem_write(self, to: &mut Semantic) {
+        match self {
+            ShortLong::Short(s) => *to += [literal('-'), literal(s)],
+            ShortLong::Long(l) => *to += [literal("--"), literal(l)],
+            ShortLong::ShortLong(s, l) => {
+                *to += [literal('-'), literal(s)];
+                *to += [text(", "), literal("--"), literal(l)];
+            }
+        }
+    }
+}
+
+impl SemWrite for meta_help::Metavar {
+    fn sem_write(self, to: &mut Semantic) {
+        *to += metavar(self.0);
+    }
+}
+
+struct UsageWithHelp<'a>(Vec<HelpItem<'a>>);
+pub struct Usage<'a>(&'a Meta);
+impl SemWrite for HelpItem<'_> {
+    fn sem_write(self, to: &mut Semantic) {
+        match self {
+            HelpItem::Decor { help } => todo!(),
+            HelpItem::BlankDecor => {}
+            HelpItem::Positional {
+                strict: _,
+                metavar,
+                help,
+            } => {
+                *to += Scoped(Block::ListKey, metavar);
+                if let Some(help) = help {
+                    *to += Scoped(Block::ListItem, text(help))
+                }
+            }
+            HelpItem::Command {
+                name,
+                short,
+                help,
+                meta: _,
+                info: _,
+            } => {
+                if let Some(short) = short {
+                    *to += WithScope(Block::ListKey, |to: &mut Semantic| {
+                        *to += literal(short);
+                        *to += [text(", "), literal(name)]
+                    });
+                } else {
+                    *to += Scoped(Block::ListKey, literal(name));
+                }
+                if let Some(help) = help {
+                    *to += Scoped(Block::ListItem, text(help));
+                }
+            }
+            HelpItem::Flag { name, help } => {
+                *to += Scoped(Block::ListKey, name.0);
+                if let Some(help) = help {
+                    *to += Scoped(Block::ListItem, text(help))
+                }
+            }
+            HelpItem::Argument {
+                name,
+                metavar,
+                env: _,
+                help,
+            } => {
+                *to += WithScope(Block::ListKey, |to: &mut Semantic| {
+                    *to += name.0;
+                    *to += mono("=");
+                    *to += metavar;
+                });
+                if let Some(help) = help {
+                    *to += Scoped(Block::ListItem, text(help))
+                }
+            }
+        }
+    }
+}
+
+impl SemWrite for UsageWithHelp<'_> {
+    fn sem_write(self, to: &mut Semantic) {
+        *to += Scoped(Block::DefinitionList, self.0);
+    }
+}
+impl Meta {
+    pub fn as_usage(&self) -> Usage {
+        Usage(self)
+    }
+}
+
+impl SemWrite for Usage<'_> {
+    fn sem_write(self, to: &mut Semantic) {
+        let mut hi = HelpItems::default();
+        hi.classify(self.0);
+
+        *to += UsageWithHelp(hi.flgs)
+    }
+}

--- a/src/docugen.rs
+++ b/src/docugen.rs
@@ -179,6 +179,19 @@ pub fn collect_help_info<T>(parser: OptionParser<T>, name: &'static str) -> Help
     }
 }
 
+/// Extract and write usage synopsis
+///
+
+pub fn synopsis<T>(parser: &OptionParser<T>) -> impl Write + '_ {
+    |doc: &mut Doc| {
+        if let Some(meta) = parser.inner.meta().to_usage_meta() {
+            doc.push(meta);
+        } else {
+            doc.text("Parser takes no parameters");
+        }
+    }
+}
+
 /// Extract and write usage for command line options used by a parser
 ///
 /// You can use this function to insert a list of items parser consumes along with help messages

--- a/src/docugen.rs
+++ b/src/docugen.rs
@@ -191,7 +191,7 @@ pub fn synopsis<T>(parser: &OptionParser<T>) -> impl Write + '_ {
         }
     }
 }
-
+/*
 // command can be created with #[bpaf(command)] or represented as a top level
 pub fn write_commands<P, T>(parser: &P) -> impl Write
 where
@@ -199,7 +199,8 @@ where
 {
     WriteCommands(parser.meta())
 }
-
+*/
+/*
 #[derive(Debug, Clone)]
 struct WriteCommands(Meta);
 
@@ -219,7 +220,7 @@ impl Write for WriteCommands {
             }
         }
     }
-}
+}*/
 
 /// Extract and write usage for command line options used by a parser
 ///

--- a/src/docugen.rs
+++ b/src/docugen.rs
@@ -137,6 +137,12 @@ impl<'a> Items<'a> {
     }
 }
 
+pub enum SectionName {
+    Never,
+    Multiple,
+    Always,
+}
+
 /// [`HelpInfo`] [`split`](HelpInfo::split) into flags, positional items and commands
 #[derive(Debug, Clone)]
 pub struct UsageItems<'a> {
@@ -173,6 +179,7 @@ pub fn collect_help_info<T>(parser: OptionParser<T>, name: &'static str) -> Help
     }
 }
 
+///
 pub fn usage<P, T>(parser: &P) -> impl Write + '_
 where
     P: Parser<T>,
@@ -184,17 +191,19 @@ where
 
 /// Extract and write comma separated flag or command names
 ///
-/// Use this if you want to refer to some other parser in parts of your documentation
+/// You can use this function to refer to some parser in your documentation. Using
+/// [`literal`](crate::roff::literal) and similar methods also work but with this function you can
+/// ensure that documentation is always up to date.
 /// ```rust
 /// # use bpaf::{docugen::*, *};
-/// fn switch_parser() -> impl Parser<bool> {
-///     short('d').long("dragon").help("Is dragon scary?").switch()
+/// fn dragon_type() -> impl Parser<bool> {
+///     short('d').long("dragon").help("Is the dragon scary?").switch()
 /// }
 ///
 /// let mut doc = Doc::default();
 /// doc.paragraph(|doc: &mut Doc| {
 ///     doc.text("You can use ")
-///         .push(names_only(&switch_parser()))
+///         .push(names_only(&dragon_type()))
 ///         .text(" to unleash the dragon.");
 ///     });
 ///

--- a/src/docugen.rs
+++ b/src/docugen.rs
@@ -192,6 +192,35 @@ pub fn synopsis<T>(parser: &OptionParser<T>) -> impl Write + '_ {
     }
 }
 
+// command can be created with #[bpaf(command)] or represented as a top level
+pub fn write_commands<P, T>(parser: &P) -> impl Write
+where
+    P: Parser<T>,
+{
+    WriteCommands(parser.meta())
+}
+
+#[derive(Debug, Clone)]
+struct WriteCommands(Meta);
+
+impl Write for WriteCommands {
+    fn write(&self, to: &mut Doc) {
+        let mut commands = Vec::new();
+        match &self.0 {
+            Meta::And(_) => todo!(),
+            Meta::Or(xs) => todo!(),
+            Meta::Optional(x) => todo!(),
+            Meta::Item(_) => todo!(),
+            Meta::Many(_) => todo!(),
+            Meta::Decorated(x, _) => (WriteCommands(*x)).write(to),
+            Meta::Skip => {}
+            Meta::HideUsage(x) => {
+                (WriteCommands(x)).write(to);
+            }
+        }
+    }
+}
+
 /// Extract and write usage for command line options used by a parser
 ///
 /// You can use this function to insert a list of items parser consumes along with help messages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,6 +460,7 @@ pub(self) use crate::parsers::NamedArg;
 pub use bpaf_derive::Bpaf;
 mod from_os_str;
 
+#[cfg(feature = "manpage")]
 pub mod docugen;
 /// Compose several parsers to produce a single result
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,6 +460,7 @@ pub(self) use crate::parsers::NamedArg;
 pub use bpaf_derive::Bpaf;
 mod from_os_str;
 
+pub mod docugen;
 /// Compose several parsers to produce a single result
 ///
 /// # Usage reference

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,8 +420,8 @@ pub use structs::{ParseBox, ParseCon};
 #[cfg(feature = "autocomplete")]
 pub use crate::complete_shell::ShellComp;
 
-#[cfg(feature = "manpage")]
-pub use manpage::Section;
+//#[cfg(feature = "manpage")]
+//pub use manpage::Section;
 
 pub mod parsers {
     //! This module exposes parsers that accept further configuration with builder pattern

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,8 +399,8 @@ mod complete_shell;
 mod help;
 mod info;
 mod item;
-#[cfg(feature = "manpage")]
-mod manpage;
+// #[cfg(feature = "manpage")]
+//mod manpage;
 mod meta;
 mod meta_help;
 mod meta_usage;

--- a/src/manpage.rs
+++ b/src/manpage.rs
@@ -1,3 +1,4 @@
+/*
 use roff::{Inline, Roff};
 
 use crate::{
@@ -9,7 +10,7 @@ use crate::{
 struct Manpage {
     roff: Roff,
 }
-
+*/
 #[derive(Debug, Clone, Copy)]
 /// Manual page section
 pub enum Section<'a> {
@@ -47,7 +48,7 @@ impl Section<'_> {
         }
     }
 }
-
+/*
 impl Manpage {
     /// Create a manpage for application
     ///
@@ -400,6 +401,19 @@ fn newline() -> Inline {
 }
 
 impl<T> OptionParser<T> {
+    #[doc(hidden)]
+    pub fn as_manpage(
+        &self,
+        app: &str,
+        section: Section,
+        date: &str,
+        authors: &str,
+        homepage: &str,
+        repo: &str,
+    ) -> String {
+        self.to_manpage(app, section, date, authors, homepage, repo)
+    }
+
     /// Render `OptionParser` as a [man page](https://en.wikipedia.org/wiki/Man_page)
     ///
     /// - `date` - date to display at the end of te man page, free form
@@ -418,14 +432,14 @@ impl<T> OptionParser<T> {
     ///
     /// #[test]
     /// fn update_test_file() {
-    ///     let manpage = options().as_manpage("sample", Section::General, "May 2020");
+    ///     let manpage = options().to_manpage("sample", Section::General, "May 2020");
     ///     std::fs::write("sample.1", manpage).expect("Unable to save manpage file");
     /// }
     /// ```
     ///
     /// Requires `manpage` feature which is disabled by default.
     #[must_use]
-    pub fn as_manpage(
+    pub fn to_manpage(
         &self,
         app: &str,
         section: Section,
@@ -449,12 +463,30 @@ impl<T> OptionParser<T> {
         });
 
         manpage.section("SYNOPSIS");
+
+        let mut commands = Vec::new();
+        for item in &hi.cmds {
+            flatten_commands(item, app, &mut commands);
+        }
+
         match meta.to_usage_meta() {
             Some(usage) => manpage.paragraph(|l| {
                 l.bold(app).space().usage(&usage);
             }),
             None => manpage.text([bold(app), norm(" takes no parameters")]),
         };
+
+        for (path, item) in &commands {
+            if let HelpItem::Command { name, meta, .. } = &item {
+                manpage.paragraph(|l| {
+                    l.bold(path).norm(" ").bold(*name);
+                    if let Some(usage) = meta.as_usage_meta() {
+                        l.norm(" ").usage(&usage);
+                    }
+                });
+            }
+            //                command_help(&mut manpage, item, path);
+        }
 
         manpage.section("DESCRIPTION");
         if let Some(header) = self.info.header {
@@ -515,3 +547,4 @@ impl<T> OptionParser<T> {
         manpage.render()
     }
 }
+*/

--- a/src/manpage.rs
+++ b/src/manpage.rs
@@ -10,7 +10,7 @@ use crate::{
 struct Manpage {
     roff: Roff,
 }
-*/
+
 #[derive(Debug, Clone, Copy)]
 /// Manual page section
 pub enum Section<'a> {
@@ -48,7 +48,7 @@ impl Section<'_> {
         }
     }
 }
-/*
+
 impl Manpage {
     /// Create a manpage for application
     ///

--- a/src/meta_usage.rs
+++ b/src/meta_usage.rs
@@ -38,6 +38,7 @@ impl Meta {
         }
     }
 }
+
 /// Transforms `Meta` to [`UsageMeta`]
 ///
 /// return value is None if parser takes no parameters at all

--- a/tests/help_format.rs
+++ b/tests/help_format.rs
@@ -162,15 +162,16 @@ Available options:
 fn enum_with_docs() {
     #[derive(Debug, Clone, Bpaf)]
     /// present
-    ///
     /// Absent
     enum Mode {
         /// help
+        /// present
         ///
         /// absent
         Intel,
 
         /// help
+        /// present
         ///
         /// Hidden
         Att,

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -1,7 +1,5 @@
 use bpaf::{docugen::*, *};
 
-use std::path::{Path, PathBuf};
-
 fn switch_parser() -> impl Parser<bool> {
     short('d').long("dragon").help("Is dragon scary?").switch()
 }
@@ -14,7 +12,10 @@ fn argument_parser() -> impl Parser<String> {
 }
 
 fn command_parser() -> impl Parser<String> {
-    argument_parser().to_options().command("unleash")
+    argument_parser()
+        .to_options()
+        .command("unleash")
+        .help("unleash the dragon")
 }
 
 #[test]
@@ -68,35 +69,33 @@ fn refer_name_command() {
 fn collect_usage_switch() {
     let mut doc = Doc::default();
 
-    doc.push(usage(&switch_parser()));
+    doc.push(usage(&switch_parser(), SectionName::Never));
     let r = doc.render_to_markdown();
-    let expected = "";
+    let expected = "<dl>\n<dt><tt><b>-d</b></tt>, <tt><b>--dragon</b></tt></dt>\n<dd>Is dragon scary?</dd></dl>";
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn collect_usage_arg() {
+    let mut doc = Doc::default();
+
+    doc.push(usage(&argument_parser(), SectionName::Never));
+    let r = doc.render_to_markdown();
+    let expected = "<dl>\n<dt><tt><b>-d</b></tt>, <tt><b>--dragon</b></tt><tt>=</tt><tt><i>NAME</i></tt></dt>\n<dd>Dragon name</dd></dl>";
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn collect_usage_command() {
+    let mut doc = Doc::default();
+
+    doc.push(usage(&command_parser(), SectionName::Never));
+    let r = doc.render_to_markdown();
+    let expected = "<dl>\n<dt><tt><b>unleash</b></tt></dt>\n<dd>unleash the dragon</dd></dl>";
     assert_eq!(r, expected);
 }
 
 /*
-fn write_updated<P: AsRef<Path>>(new_val: &str, path: P) -> std::io::Result<()> {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join(path);
-    let mut file = OpenOptions::new()
-        .write(true)
-        .read(true)
-        .create(true)
-        .open(&path)?;
-    let mut current_val = String::new();
-    file.read_to_string(&mut current_val)?;
-    if current_val != new_val {
-        file.set_len(0)?;
-        file.seek(std::io::SeekFrom::Start(0))?;
-        std::io::Write::write_all(&mut file, new_val.as_bytes())?;
-        panic!(
-            "Please make sure to check rendering of {:?} and commit it to the repo",
-            path
-        );
-    }
-    Ok(())
-}
 
 #[test]
 fn simple_manpage() {

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -136,6 +136,50 @@ fn render_full_parser() {
         /// And long description
         flag: bool,
     }
+
+    todo!();
+}
+
+#[test]
+fn render_commands() {
+    #[derive(Debug, Clone, Bpaf)]
+    /// ignored
+    #[allow(dead_code)]
+    enum Cmds {
+        #[bpaf(command)]
+        /// alpha short help
+        ///
+        ///
+        /// alpha long help
+        Alpha,
+        /// beta short help
+        ///
+        ///
+        /// beta long help
+        #[bpaf(command)]
+        Beta {
+            /// epsilon short help
+            ///
+            ///
+            /// epsilon long help
+            epsilon: bool,
+        },
+    }
+
+    let mut doc = Doc::default();
+
+    let parser = cmds();
+    doc.section("--------------------------");
+    doc.push(synopsis(&parser));
+    doc.push(usage(&parser, SectionName::Always));
+    doc.section("--------------------------");
+
+    write_commands(&parser, None::<&str>, &mut doc);
+    let r = doc.render_to_markdown();
+
+    let expected = "";
+    println!("{r}");
+    assert_eq!(r, expected);
 }
 
 /*

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -117,6 +117,27 @@ fn render_synopsis_sw() {
     assert_eq!(r, expected);
 }
 
+#[test]
+fn render_full_parser() {
+    #[derive(Debug, Clone, Bpaf)]
+    /// Help title
+    ///
+    /// Help header
+    ///
+    /// Help footer
+    ///
+    /// More The rest of the help
+    #[allow(dead_code)]
+    #[bpaf(options)]
+    struct Opts {
+        /// A strange flag
+        /// With short description
+        ///
+        /// And long description
+        flag: bool,
+    }
+}
+
 /*
 
 #[test]

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -145,6 +145,7 @@ fn render_commands() {
     #[derive(Debug, Clone, Bpaf)]
     /// ignored
     #[allow(dead_code)]
+    #[bpaf(options)]
     enum Cmds {
         #[bpaf(command)]
         /// alpha short help
@@ -170,8 +171,8 @@ fn render_commands() {
 
     let parser = cmds();
     doc.section("--------------------------");
-    doc.push(synopsis(&parser));
-    doc.push(usage(&parser, SectionName::Always));
+    doc.push(&synopsis(&parser));
+    doc.push(&usage(&parser, SectionName::Always));
     doc.section("--------------------------");
 
     write_commands(&parser, None::<&str>, &mut doc);

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -64,6 +64,16 @@ fn refer_name_command() {
     assert_eq!(r, expected);
 }
 
+#[test]
+fn collect_usage_switch() {
+    let mut doc = Doc::default();
+
+    doc.push(usage(&switch_parser()));
+    let r = doc.render_to_markdown();
+    let expected = "";
+    assert_eq!(r, expected);
+}
+
 /*
 fn write_updated<P: AsRef<Path>>(new_val: &str, path: P) -> std::io::Result<()> {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -1,7 +1,5 @@
-use bpaf::{docugen::roff::semantic::*, docugen::*, *};
+use bpaf::{docugen::*, *};
 
-use std::fs::OpenOptions;
-use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
 
 fn switch_parser() -> impl Parser<bool> {
@@ -21,44 +19,48 @@ fn command_parser() -> impl Parser<String> {
 
 #[test]
 fn refer_name_switch() {
-    let mut doc = Semantic::default();
+    let mut doc = Doc::default();
 
-    doc.paragraph(write_with(|doc| {
-        doc.text(text("Prefix "));
-        *doc += names_only(&switch_parser())
-    }));
+    doc.paragraph(|doc: &mut Doc| {
+        doc.text("You can use ")
+            .push(names_only(&switch_parser()))
+            .text(" to unleash the dragon.");
+    });
 
     let r = doc.render_to_markdown();
-    let expected = "Prefix <tt><b>\\-d</b></tt>, <tt><b>\\-\\-dragon</b></tt>";
+
+    let expected =
+        "<p>You can use <tt><b>-d</b></tt>, <tt><b>--dragon</b></tt> to unleash the dragon.</p>";
     assert_eq!(r, expected);
 }
 
 #[test]
 fn refer_name_arg() {
-    let mut doc = Semantic::default();
+    let mut doc = Doc::default();
 
-    doc.paragraph(write_with(|doc| {
-        doc.text(text("Prefix "));
-        *doc += names_only(&argument_parser())
-    }));
+    doc.paragraph(|doc: &mut Doc| {
+        doc.text("You can use ")
+            .push(names_only(&argument_parser()))
+            .text(" to specify dragon's name.");
+    });
 
     let r = doc.render_to_markdown();
-    let expected =
-        "Prefix <tt><b>\\-d</b></tt>, <tt><b>\\-\\-dragon</b></tt><tt> </tt><tt><i>NAME</i></tt>";
+    let expected = "<p>You can use <tt><b>-d</b></tt>, <tt><b>--dragon</b></tt><tt> </tt><tt><i>NAME</i></tt> to specify dragon's name.</p>";
     assert_eq!(r, expected);
 }
 
 #[test]
 fn refer_name_command() {
-    let mut doc = Semantic::default();
+    let mut doc = Doc::default();
 
-    doc.paragraph(write_with(|doc| {
-        doc.text(text("Prefix "));
-        *doc += names_only(&command_parser())
-    }));
+    doc.paragraph(|doc: &mut Doc| {
+        doc.text("You can use ")
+            .push(names_only(&command_parser()))
+            .text(" command too.");
+    });
 
     let r = doc.render_to_markdown();
-    let expected = "Prefix <tt><b>unleash</b></tt>";
+    let expected = "<p>You can use <tt><b>unleash</b></tt> command too.</p>";
     assert_eq!(r, expected);
 }
 

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -1,4 +1,30 @@
 use bpaf::*;
+use std::fs::OpenOptions;
+use std::io::{Read, Seek};
+use std::path::{Path, PathBuf};
+/*
+fn write_updated<P: AsRef<Path>>(new_val: &str, path: P) -> std::io::Result<()> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join(path);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .read(true)
+        .create(true)
+        .open(&path)?;
+    let mut current_val = String::new();
+    file.read_to_string(&mut current_val)?;
+    if current_val != new_val {
+        file.set_len(0)?;
+        file.seek(std::io::SeekFrom::Start(0))?;
+        std::io::Write::write_all(&mut file, new_val.as_bytes())?;
+        panic!(
+            "Please make sure to check rendering of {:?} and commit it to the repo",
+            path
+        );
+    }
+    Ok(())
+}
 
 #[test]
 fn simple_manpage() {
@@ -10,7 +36,7 @@ fn simple_manpage() {
         .descr("I am a program and I do things")
         .header("Sometimes they even work.")
         .footer("Beware `-d`, dragons be here")
-        .as_manpage(
+        .to_manpage(
             "simple",
             Section::General,
             "Aug 2022",
@@ -59,7 +85,7 @@ fn nested_command_manpage() {
         .descr("I am a program and I do things 3")
         .header("Sometimes they even work. 3")
         .footer("Beware `-d`, dragons be here 3")
-        .as_manpage(
+        .to_manpage(
             "nested",
             Section::General,
             "29 Nov 2022",
@@ -90,7 +116,7 @@ fn very_nested_command() {
         .descr("lvl 1 description")
         .command("lvl1")
         .to_options()
-        .as_manpage(
+        .to_manpage(
             "nested",
             Section::General,
             "29 Nov 2022",
@@ -102,3 +128,4 @@ fn very_nested_command() {
     let expected = ".ie \\n(.g .ds Aq \\(aq\n.el .ds Aq '\n.TH nested 1 \"29 Nov 2022\" - \n.SH NAME\n\nnested\n.SH SYNOPSIS\n\n\\fBnested\\fR \\fBCOMMAND\\fR...\n.SH DESCRIPTION\n.SS \"List of all the subcommands\"\n.TP\n\n\\fBnested\\fR \\fBlvl1\\fR\nlvl 1 description\n.TP\n\n\\fBnested lvl1\\fR \\fBlvl2\\fR\nlvl 2 description\n.TP\n\n\\fBnested lvl1 lvl2\\fR \\fBlvl3\\fR\nlvl 3 description\n.TP\n\n\\fBnested lvl1 lvl2 lvl3\\fR \\fBlvl4\\fR\nlvl 4 description\n.SH \"SUBCOMMANDS WITH OPTIONS\"\n.SS \"nested lvl1\"\nlvl 1 description\n.SS \"nested lvl1 lvl2\"\nlvl 2 description\n.SS \"nested lvl1 lvl2 lvl3\"\nlvl 3 description\n.SS \"nested lvl1 lvl2 lvl3 lvl4\"\nlvl 4 description\n.SS \"Option arguments and flags\"\n.TP\n\n\\fB\\-k\\fR\nUnleash the Kraken\n.SH AUTHORS\nMichael Baykov <manpacket@gmail.com>\n.SH \"REPORTING BUGS\"\nhttps://github.com/pacak/bpaf\n";
     assert_eq!(manpage, expected);
 }
+*/

--- a/tests/manpage.rs
+++ b/tests/manpage.rs
@@ -46,7 +46,7 @@ fn refer_name_arg() {
     });
 
     let r = doc.render_to_markdown();
-    let expected = "<p>You can use <tt><b>-d</b></tt>, <tt><b>--dragon</b></tt><tt> </tt><tt><i>NAME</i></tt> to specify dragon's name.</p>";
+    let expected = "<p>You can use <tt><b>-d</b></tt>, <tt><b>--dragon</b> <i>NAME</i></tt> to specify dragon's name.</p>";
     assert_eq!(r, expected);
 }
 
@@ -81,7 +81,7 @@ fn collect_usage_arg() {
 
     doc.push(usage(&argument_parser(), SectionName::Never));
     let r = doc.render_to_markdown();
-    let expected = "<dl>\n<dt><tt><b>-d</b></tt>, <tt><b>--dragon</b></tt><tt>=</tt><tt><i>NAME</i></tt></dt>\n<dd>Dragon name</dd></dl>";
+    let expected = "<dl>\n<dt><tt><b>-d</b></tt>, <tt><b>--dragon</b>=<i>NAME</i></tt></dt>\n<dd>Dragon name</dd></dl>";
     assert_eq!(r, expected);
 }
 
@@ -92,6 +92,28 @@ fn collect_usage_command() {
     doc.push(usage(&command_parser(), SectionName::Never));
     let r = doc.render_to_markdown();
     let expected = "<dl>\n<dt><tt><b>unleash</b></tt></dt>\n<dd>unleash the dragon</dd></dl>";
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn render_synopsis_arg() {
+    let mut doc = Doc::default();
+    let parser = argument_parser().optional().to_options();
+    doc.section("Synopsis");
+    doc.push(synopsis(&parser));
+    let r = doc.render_to_markdown();
+    let expected = "# Synopsis\n\n<tt>[<b>-d</b>=<i>NAME</i>]</tt>";
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn render_synopsis_sw() {
+    let mut doc = Doc::default();
+    let parser = switch_parser().to_options();
+    doc.section("Synopsis");
+    doc.push(synopsis(&parser));
+    let r = doc.render_to_markdown();
+    let expected = "# Synopsis\n\n<tt>[<b>-d</b>]</tt>";
     assert_eq!(r, expected);
 }
 

--- a/tests/nested_command_manpage.1
+++ b/tests/nested_command_manpage.1
@@ -1,0 +1,33 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH nested 1 "29 Nov 2022" -
+.SH NAME
+
+nested \- I am a program and I do things 3
+.SH SYNOPSIS
+
+\fBnested\fR \-\fBd\fR=\fID\fR \fIC\fR \fBCOMMAND\fR...
+
+\fBnested\fR \fBcmd\fR \-\fBd\fR=\fIy\fR
+
+\fBnested\fR \fBdmc\fR \-\fBk\fR=\fIx\fR
+.SH DESCRIPTION
+Sometimes they even work. 3
+.br
+
+Beware `\-d`, dragons be here 3
+.br
+
+.SH OPTIONS
+.TP
+
+\fB\-d\fR, \fB\-\-ddd\fR=\fID\fR
+mystery arg
+.TP
+
+\fIC\fR
+Mystery file
+.SH AUTHORS
+Michael Baykov <manpacket@gmail.com>
+.SH "REPORTING BUGS"
+https://github.com/pacak/bpaf

--- a/tests/sample.1
+++ b/tests/sample.1
@@ -1,16 +1,16 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH ls 1 1\ Jan\ 2023 rust\ toolbox File\ lister\ 2000
+.TH ls 1 1\ Jan\ 2023 rust\ toolbox
 .SH NAME
-\f(CRls\fP\fR \- List directory contents\fP
 .PP
+\f(CRls\fP\fR \- List directory contents\fP
 .SH DESCRIPTION
+.PP
 \fRList information about the FILEs (the current directory by default).
 Prints name only unless `\-\-long` is specified
     Exit status:
       0: if OK
       1: if requested FILEs does not exist\fP
-.PP
 .SS Available\ positional\ items
 .TP
 \fIFILE\fP

--- a/tests/sample.1
+++ b/tests/sample.1
@@ -1,0 +1,23 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH ls 1 1\ Jan\ 2023 rust\ toolbox File\ lister\ 2000
+.SH NAME
+\f(CRls\fP\fR \- List directory contents\fP
+.PP
+.SH DESCRIPTION
+\fRList information about the FILEs (the current directory by default).
+Prints name only unless `\-\-long` is specified
+    Exit status:
+      0: if OK
+      1: if requested FILEs does not exist\fP
+.PP
+.SS Available\ positional\ items
+.TP
+\fIFILE\fP
+\fRuse specific paths instead of current directory\fP
+.PP
+.SS Available\ options
+.TP
+\f(CB\-l\fP\fR, \fP\f(CB\-\-long\fP
+\fRuse a long listing format\fP
+.PP

--- a/tests/sample.md
+++ b/tests/sample.md
@@ -1,0 +1,23 @@
+# Name
+
+<tt>ls</tt> - List directory contents
+
+# Description
+
+List information about the FILEs (the current directory by default).
+Prints name only unless `--long` is specified
+    Exit status:
+      0: if OK
+      1: if requested FILEs does not exist
+
+## Available positional items
+
+<dl>
+<dt><tt><i>FILE</i></tt></dt>
+<dd>use specific paths instead of current directory</dd></dl>
+
+## Available options
+
+<dl>
+<dt><tt><b>-l</b></tt>, <tt><b>--long</b></tt></dt>
+<dd>use a long listing format</dd></dl>

--- a/tests/sample.md
+++ b/tests/sample.md
@@ -1,14 +1,14 @@
 # Name
 
-<tt>ls</tt> - List directory contents
+<p><tt>ls</tt> - List directory contents</p>
 
 # Description
 
-List information about the FILEs (the current directory by default).
+<p>List information about the FILEs (the current directory by default).
 Prints name only unless `--long` is specified
     Exit status:
       0: if OK
-      1: if requested FILEs does not exist
+      1: if requested FILEs does not exist</p>
 
 ## Available positional items
 

--- a/tests/sample.txt
+++ b/tests/sample.txt
@@ -1,0 +1,19 @@
+    ls(1)                          File lister 2000                          ls(1)
+
+    Name
+           ls - List directory contents
+
+    Description
+           List  information  about  the FILEs (the current directory by default).
+           Prints name only unless --long is specified
+
+       Available positional items
+           FILE   use specific paths instead of current directory
+
+       Available options
+           -l, --long
+                  use a long listing format
+
+           Exit status: - 0: if OK - 1: if requested FILEs does not exist
+
+    rust toolbox                      1 Jan 2023                             ls(1)

--- a/tests/very_nested_command.1
+++ b/tests/very_nested_command.1
@@ -1,0 +1,22 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH nested 1 "29 Nov 2022" -
+.SH NAME
+
+nested
+.SH SYNOPSIS
+
+\fBnested\fR \fBCOMMAND\fR...
+
+\fBnested\fR \fBlvl1\fR \fBCOMMAND\fR...
+
+\fBnested lvl1\fR \fBlvl2\fR \fBCOMMAND\fR...
+
+\fBnested lvl1 lvl2\fR \fBlvl3\fR \fBCOMMAND\fR...
+
+\fBnested lvl1 lvl2 lvl3\fR \fBlvl4\fR [\-\fBk\fR]
+.SH DESCRIPTION
+.SH AUTHORS
+Michael Baykov <manpacket@gmail.com>
+.SH "REPORTING BUGS"
+https://github.com/pacak/bpaf


### PR DESCRIPTION
Adds an option to generate documentation using metadata available inside parsers


cc @ysndr 

A second iteration of documentation generation, added some more documentation and implemented some examples how I would use it as the end user in `cargo-show-asm`. Changed more things into methods

- https://github.com/pacak/semantic/tree/semantic
- https://github.com/pacak/bpaf/tree/semantic (this MR)
- https://github.com/pacak/cargo-show-asm/tree/semantic