### PR TITLE
Release bpaf 0.8.0 and bpaf_derive 0.4.0

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -56,14 +56,17 @@ jobs:
       - name: test all features
         run: cargo test --workspace --all-targets --all-features
 
-      - name: example documentation
-        run: cargo build --all-features -p docs && git diff && git diff-index --quiet HEAD --
+      - name: Example documentation
+        run: cargo build --all-features -p docs
+        run: git diff
+        run: git diff-index --quiet HEAD --
 
       - name: Rustdoc
         run: cargo doc --all --no-deps --all-features
 
       - name: formatting
-        run: touch docs/src/lib.rs && cargo fmt --all -- --check
+        run: touch docs/src/lib.rs
+        run: cargo fmt --all -- --check
 
 
   compat:

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -79,13 +79,13 @@ jobs:
           components: rustfmt clippy
 
       - name: test minimal features
-        run: cargo test --no-default-features
+        run: cargo test --no-default-features --lib --tests
 
       - name: test default features
-        run: cargo test
+        run: cargo test --lib --tests
 
       - name: test all features
-        run: cargo test --all-features
+        run: cargo test --all-features --lib --tests
 
       - name: derive
         run: cargo test -p bpaf_derive --lib --tests --no-default-features

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -57,17 +57,13 @@ jobs:
         run: cargo test --workspace --all-targets --all-features
 
       - name: Example documentation
-        run: cargo build --all-features -p docs
-        run: git diff
-        run: git diff-index --quiet HEAD --
+        run: cargo build --all-features -p docs &&  git diff && git diff-index --quiet HEAD --
 
       - name: Rustdoc
         run: cargo doc --all --no-deps --all-features
 
       - name: formatting
-        run: touch docs/src/lib.rs
-        run: cargo fmt --all -- --check
-
+        run: touch docs/src/lib.rs && cargo fmt --all -- --check
 
   compat:
     name: Tests on linux with old toolchain

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -9,147 +9,84 @@ name: Check and Lint
 
 jobs:
   windows:
+    name: Tests on windows
     runs-on: windows-latest
-    name: Check windows
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets
 
-      - uses: actions-rs/cargo@v1
-        name: all features
-        with:
-          command: test
-          args: --workspace --all-targets --all-features
+      - name: Tests
+        run: cargo test --workspace --all-targets --all-features
 
-  check:
-    name: Check linux
+  linux:
+    name: Tests, formatting and clippy on linux
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
+          components: rustfmt clippy
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets
+      - name: clippy minimal features
+        run: cargo clippy --workspace --all-targets --no-default-features
 
-      - uses: actions-rs/cargo@v1
-        name: all features
-        with:
-          command: test
-          args: --workspace --all-targets --all-features
+      - name: clippy default features
+        run: cargo clippy --workspace --all-targets
 
-      # without autocomplete
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-targets --no-default-features
+      - name: clippy all features
+        run: cargo clippy --workspace --all-targets --all-features
 
-      - uses: actions-rs/cargo@v1
-        name: all features
-        with:
-          command: test
-          args: --workspace --doc --all-features
+      - name: test minimal features
+        run: cargo test --workspace --all-targets --no-default-features
 
-      # without autocomplete
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --doc --no-default-features
+      - name: test default features
+        run: cargo test --workspace --all-targets
+
+      - name: test all features
+        run: cargo test --workspace --all-targets --all-features
 
       - name: example documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-features -p docs
-
-      - name: should not have any changes
-        run: git diff && git diff-index --quiet HEAD --
+        run: cargo build --all-features -p docs && git diff && git diff-index --quiet HEAD --
 
       - name: Rustdoc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all --no-deps --all-features
-        env:
-          RUSTDOCFLAGS: '-D warnings'
+        run: cargo doc --all --no-deps --all-features
 
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - run: echo "" > docs/src/lib.rs
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: formatting
+        run: touch docs/src/lib.rs && cargo fmt --all -- --check
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
-          name: Clippy Output
+
   compat:
-    name: Check compat 1.56
+    name: Tests on linux with old toolchain
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.56.0
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -p bpaf
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: actions-rs/cargo@v1
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: check
-          args: -p bpaf_derive
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p bpaf --lib --tests --no-default-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p bpaf --lib --tests --all-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p bpaf_derive --lib --tests --no-default-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p bpaf_derive --lib --tests --all-features
+          toolchain: 1.56
+          components: rustfmt clippy
+
+      - name: test minimal features
+        run: cargo test --no-default-features
+
+      - name: test default features
+        run: cargo test
+
+      - name: test all features
+        run: cargo test --all-features
+
+      - name: derive
+        run: cargo test -p bpaf_derive --lib --tests --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.7.10"
+version = "0.8.0"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -14,7 +14,7 @@ exclude = [".github/workflows", "tarp.sh"]
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.3.5", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.4.0", optional = true }
 owo-colors = { version = "3.5.0", features = ["supports-colors"], optional = true }
 roff = { version = "0.2.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ owo-colors = { version = "3.5.0", features = ["supports-colors"], optional = tru
 roff = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
-bpaf = { path = ".",  features = ["derive", "extradocs", "autocomplete", "manpage"] }
+bpaf = { path = ".",  features = ["derive", "extradocs", "autocomplete", "manpage", "batteries"] }
 
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Lightweight and flexible command line argument parser with derive and combinator
 
  - [Derive tutorial][__link0]
  - [Combinatoric tutorial][__link1]
- - [Some very unusual cases][__link2]
+ - [Dealing with unusual cases][__link2]
  - [Applicative functors? What is it all about][__link3]
- - [Batteries included][__link4]
- - [Q&A][__link5]
+ - [Applicative parsing intro][__link4]
+ - [Batteries included][__link5]
+ - [Q&A][__link6]
 
 
 ## Quick start - combinatoric and derive APIs
@@ -83,7 +84,7 @@ Lightweight and flexible command line argument parser with derive and combinator
 	```
 	
 	
- 1. You can check the [derive tutorial][__link6] for more detailed information.
+ 1. You can check the [derive tutorial][__link7] for more detailed information.
 	
 	
 
@@ -163,7 +164,7 @@ Lightweight and flexible command line argument parser with derive and combinator
 	```
 	
 	
- 1. You can check the [combinatoric tutorial][__link7] for more detailed information.
+ 1. You can check the [combinatoric tutorial][__link8] for more detailed information.
 	
 	
 
@@ -222,7 +223,7 @@ Library follows **parse, don’t validate** approach to validation when possible
 
 ## Design goals: restrictions
 
-The main restricting library sets is that you can’t use parsed values (but not the fact that parser succeeded or failed) to decide how to parse subsequent values. In other words parsers don’t have the monadic strength, only the applicative one - for more detailed explanation see [Applicative functors? What is it all about][__link8].
+The main restricting library sets is that you can’t use parsed values (but not the fact that parser succeeded or failed) to decide how to parse subsequent values. In other words parsers don’t have the monadic strength, only the applicative one - for more detailed explanation see [Applicative functors? What is it all about][__link9].
 
 To give an example, you can implement this description:
 
@@ -238,9 +239,9 @@ But not this one:
 > 
 This set of restrictions allows `bpaf` to extract information about the structure of the computations to generate help, dynamic completion and overall results in less confusing enduser experience
 
-`bpaf` performs no parameter names validation, in fact having multiple parameters with the same name is fine and you can combine them as alternatives and performs no fallback other than [`fallback`][__link9]. You need to pay attention to the order of the alternatives inside the macro: parser that consumes the left most available argument on a command line wins, if this is the same - left most parser wins. So to parse a parameter `--test` that can be both [`switch`][__link10] and [`argument`][__link11] you should put the argument one first.
+`bpaf` performs no parameter names validation, in fact having multiple parameters with the same name is fine and you can combine them as alternatives and performs no fallback other than [`fallback`][__link10]. You need to pay attention to the order of the alternatives inside the macro: parser that consumes the left most available argument on a command line wins, if this is the same - left most parser wins. So to parse a parameter `--test` that can be both [`switch`][__link11] and [`argument`][__link12] you should put the argument one first.
 
-You must place [`positional`][__link12] items at the end of a structure in derive API or consume them as last arguments in derive API.
+You must place [`positional`][__link13] items at the end of a structure in derive API or consume them as last arguments in derive API.
 
 
 ## Dynamic shell completion
@@ -255,7 +256,7 @@ You must place [`positional`][__link12] items at the end of a structure in deriv
 	```
 	
 	
- 1. Decorate [`argument`][__link13] and [`positional`][__link14] parsers with [`complete`][__link15] to autocomplete argument values
+ 1. Decorate [`argument`][__link14] and [`positional`][__link15] parsers with [`complete`][__link16] to autocomplete argument values
 	
 	
  1. Depending on your shell generate appropriate completion file and place it to whereever your shell is going to look for it, name of the file should correspond in some way to name of your program. Consult manual for your shell for the location and named conventions:
@@ -299,11 +300,6 @@ You must place [`positional`][__link12] items at the end of a structure in deriv
 	
 
 
-## Design non goals: performance
-
-Library aims to optimize for flexibility, reusability and compilation time over runtime performance which means it might perform some additional clones, allocations and other less optimal things. In practice unless you are parsing tens of thousands of different parameters and your app exits within microseconds - this won’t affect you. That said - any actual performance related problems with real world applications is a bug.
-
-
 ## More examples
 
 You can find a more examples here: <https://github.com/pacak/bpaf/tree/master/examples>
@@ -318,7 +314,7 @@ $ cargo run --example example_name
 
 ## Testing your own parsers
 
-You can test your own parsers to maintain compatibility or simply checking expected output with [`run_inner`][__link17]
+You can test your own parsers to maintain compatibility or simply checking expected output with [`run_inner`][__link18]
 
 
 ```rust
@@ -370,27 +366,28 @@ Usage --user <ARG>
 	Disabled by default.
 	
 	
- - `manpage`: generate man page from help declaration, see [`OptionParser::as_manpage`][__link20]. Disabled by default.
+ - `manpage`: generate man page from help declaration, see [`OptionParser::as_manpage`][__link21]. Disabled by default.
 	
 	
 
 
- [__cargo_doc2readme_dependencies_info]: ggGkYW0AYXSEG52uRQSwBdezG6GWW8ODAbr5G6KRmT_WpUB5G9hPmBcUiIp6YXKEGwet03UV33_nG7BNDOumJDcWG2J9NgcAg8w5G_uDmsZYklJQYWSBgmRicGFmZTAuNy43
- [__link0]: https://docs.rs/bpaf/0.7.7/bpaf/?search=_derive_tutorial
- [__link1]: https://docs.rs/bpaf/0.7.7/bpaf/?search=_combinatoric_tutorial
- [__link10]: https://docs.rs/bpaf/0.7.7/bpaf/?search=parsers::NamedArg::switch
- [__link11]: https://docs.rs/bpaf/0.7.7/bpaf/?search=parsers::NamedArg::argument
- [__link12]: https://docs.rs/bpaf/0.7.7/bpaf/?search=params::positional
- [__link13]: https://docs.rs/bpaf/0.7.7/bpaf/?search=parsers::NamedArg::argument
- [__link14]: https://docs.rs/bpaf/0.7.7/bpaf/?search=params::positional
- [__link15]: https://docs.rs/bpaf/0.7.7/bpaf/?search=bpaf::Parser::complete
- [__link17]: https://docs.rs/bpaf/0.7.7/bpaf/?search=info::OptionParser::run_inner
- [__link2]: https://docs.rs/bpaf/0.7.7/bpaf/?search=_unusual
- [__link20]: https://docs.rs/bpaf/0.7.7/bpaf/?search=info::OptionParser::as_manpage
- [__link3]: https://docs.rs/bpaf/0.7.7/bpaf/?search=_applicative
- [__link4]: https://docs.rs/bpaf/0.7.7/bpaf/?search=batteries
- [__link5]: https://github.com/pacak/bpaf/discussions/categories/q-a
- [__link6]: https://docs.rs/bpaf/0.7.7/bpaf/?search=_derive_tutorial
- [__link7]: https://docs.rs/bpaf/0.7.7/bpaf/?search=_combinatoric_tutorial
- [__link8]: https://docs.rs/bpaf/0.7.7/bpaf/?search=_applicative
- [__link9]: https://docs.rs/bpaf/0.7.7/bpaf/?search=bpaf::Parser::fallback
+ [__cargo_doc2readme_dependencies_info]: ggGkYW0AYXSEG52uRQSwBdezG6GWW8ODAbr5G6KRmT_WpUB5G9hPmBcUiIp6YXKEG67Vn_d8EgCjGwx1q1eGjg8OG62q7Al6912tG9tijfvWADwPYWSBgmRicGFmZTAuOC4w
+ [__link0]: https://docs.rs/bpaf/0.8.0/bpaf/?search=_derive_tutorial
+ [__link1]: https://docs.rs/bpaf/0.8.0/bpaf/?search=_combinatoric_tutorial
+ [__link10]: https://docs.rs/bpaf/0.8.0/bpaf/?search=bpaf::Parser::fallback
+ [__link11]: https://docs.rs/bpaf/0.8.0/bpaf/?search=parsers::NamedArg::switch
+ [__link12]: https://docs.rs/bpaf/0.8.0/bpaf/?search=parsers::NamedArg::argument
+ [__link13]: https://docs.rs/bpaf/0.8.0/bpaf/?search=params::positional
+ [__link14]: https://docs.rs/bpaf/0.8.0/bpaf/?search=parsers::NamedArg::argument
+ [__link15]: https://docs.rs/bpaf/0.8.0/bpaf/?search=params::positional
+ [__link16]: https://docs.rs/bpaf/0.8.0/bpaf/?search=bpaf::Parser::complete
+ [__link18]: https://docs.rs/bpaf/0.8.0/bpaf/?search=info::OptionParser::run_inner
+ [__link2]: https://docs.rs/bpaf/0.8.0/bpaf/?search=_unusual
+ [__link21]: https://docs.rs/bpaf/0.8.0/bpaf/?search=info::OptionParser::as_manpage
+ [__link3]: https://docs.rs/bpaf/0.8.0/bpaf/?search=_applicative
+ [__link4]: https://rustmagazine.org/issue-2/applicative-parsing/
+ [__link5]: https://docs.rs/bpaf/0.8.0/bpaf/?search=batteries
+ [__link6]: https://github.com/pacak/bpaf/discussions/categories/q-a
+ [__link7]: https://docs.rs/bpaf/0.8.0/bpaf/?search=_derive_tutorial
+ [__link8]: https://docs.rs/bpaf/0.8.0/bpaf/?search=_combinatoric_tutorial
+ [__link9]: https://docs.rs/bpaf/0.8.0/bpaf/?search=_applicative

--- a/bpaf_cauwugo/Cargo.toml
+++ b/bpaf_cauwugo/Cargo.toml
@@ -12,7 +12,7 @@ description = "A cargo frontend with dynamic completion"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bpaf = { version = "0.7.4", path = "../", features = ["derive", "autocomplete"] }
+bpaf = { version = "0.8.0", path = "../", features = ["derive", "autocomplete"] }
 cargo_metadata = "0.15.0"
 once_cell = "1.13.1"
 

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"

--- a/src/_unusual.rs
+++ b/src/_unusual.rs
@@ -22,12 +22,15 @@ pub mod xorg {}
 
 /// ## [Command chaining](https://click.palletsprojects.com/en/7.x/commands/#multi-command-chaining): `setup.py sdist bdist`
 ///
-/// Unlike `click`, `bpaf` allows commands to be nested as well for as long as the paring is not
-/// ambiguous
+/// With [`adjacent`](crate::parsers::ParseCommand::adjacent)
+/// `bpaf` allows you to have several commands side by side instead of being nested.
 #[doc = include_str!("docs/adjacent_2.md")]
 pub mod chaining {}
 
 /// ## Multi-value arguments: `--foo ARG1 ARG2 ARG3`
+///
+/// By default arguments take at most one value, you can create multi value options by using
+/// [`adjacent`](crate::parsers::ParseCon::adjacent) modifier
 #[doc = include_str!("docs/adjacent_0.md")]
 pub mod multi_value {}
 
@@ -69,9 +72,9 @@ pub mod optional_pos {}
 #[cfg(feature = "batteries")]
 /// # Implementing cargo commands
 ///
-/// With [`cargo_helper`] you can use your application as cargo command
+/// With [`cargo_helper`](crate::batteries::cargo_helper) you can use your application as a `cargo` command
 #[doc = include_str!("docs/cargo_helper.md")]
-pub mod cargohelper {}
+pub mod cargo_helper {}
 
 #[cfg(all(doc, feature = "batteries"))]
 use crate::batteries::cargo_helper;

--- a/src/batteries.rs
+++ b/src/batteries.rs
@@ -8,7 +8,7 @@
 //! Examples contain combinatoric usage, for derive usage you should create a parser function and
 //! use `external` annotation.
 
-use crate::{construct, parsers::NamedArg, positional, short, Parser};
+use crate::{construct, literal, parsers::NamedArg, short, Parser};
 
 /// `--verbose` and `--quiet` flags with results encoded as number
 ///
@@ -158,11 +158,7 @@ pub fn cargo_helper<P, T>(cmd: &'static str, parser: P) -> impl Parser<T>
 where
     P: Parser<T>,
 {
-    let skip = positional::<String>("cmd")
-        .guard(move |s| s == cmd, "")
-        .optional()
-        .catch()
-        .hide();
+    let skip = literal(cmd).optional().hide();
     construct!(skip, parser).map(|x| x.1)
 }
 

--- a/src/batteries.rs
+++ b/src/batteries.rs
@@ -144,12 +144,10 @@ pub fn toggle_flag<T: Copy + 'static>(
 /// with name present when used via cargo and without it when used locally.
 ///
 /// You can read the code of this function as this approximate sequence of statements:
-/// 1. Want to parse a word
-/// 2. Word must match a given string literal
-/// 3. It's okay if it's missing
-/// 4. It's also okay when it's not matching expectations, don't consume it in this case
-/// 5. And don't show anything to the user in `--help` or completion
-/// 6. Parse this word and then everything else as a tuple, return that second item.
+/// 1. Try to parse a string literal that corresponds to a command name
+/// 2. It's okay if it's missing
+/// 3. And don't show anything to the user in `--help` or completion
+/// 4. Parse this word and then everything else as a tuple, return that second item.
 ///
 #[doc = include_str!("docs/cargo_helper.md")]
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! - [Derive tutorial](crate::_derive_tutorial)
 //! - [Combinatoric tutorial](crate::_combinatoric_tutorial)
-//! - [Some very unusual cases](crate::_unusual)
+//! - [Dealing with unusual cases](crate::_unusual)
 //! - [Applicative functors? What is it all about](crate::_applicative)
 //! - [Applicative parsing intro](https://rustmagazine.org/issue-2/applicative-parsing/)
 //! - [Batteries included](crate::batteries)
@@ -429,7 +429,9 @@ pub mod parsers {
     #[doc(inline)]
     pub use crate::params::{NamedArg, ParseAny, ParseArgument, ParseCommand, ParsePositional};
     #[doc(inline)]
-    pub use crate::structs::{ParseBox, ParseFallback, ParseMany, ParseOptional, ParseSome};
+    pub use crate::structs::{
+        ParseBox, ParseCon, ParseFallback, ParseMany, ParseOptional, ParseSome,
+    };
 }
 
 use structs::{
@@ -818,7 +820,7 @@ pub trait Parser<T> {
 
     // change shape
     // {{{ many
-    /// Consume zero or more items from a command line and collect them into [`Vec`]
+    /// Consume zero or more items from a command line and collect them into a [`Vec`]
     ///
     /// `many` preserves any parsing falures and propagates them outwards, with extra
     /// [`catch`](ParseMany::catch) statement you can instead stop at the first value
@@ -848,7 +850,7 @@ pub trait Parser<T> {
     // }}}
 
     // {{{ some
-    /// Consume one or more items from a command line
+    /// Consume one or more items from a command line and collect them into a [`Vec`]
     ///
     /// Takes a string used as an error message if there's no specified parameters
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,14 +287,6 @@
 //!
 //! 5. Generated scripts rely on your program being accessible in $PATH
 
-//! # Design non goals: performance
-//!
-//! Library aims to optimize for flexibility, reusability and compilation time over runtime
-//! performance which means it might perform some additional clones, allocations and other less
-//! optimal things. In practice unless you are parsing tens of thousands of different parameters
-//! and your app exits within microseconds - this won't affect you. That said - any actual
-//! performance related problems with real world applications is a bug.
-
 //! # More examples
 //!
 //! You can find a more examples here: <https://github.com/pacak/bpaf/tree/master/examples>

--- a/src/meta_help.rs
+++ b/src/meta_help.rs
@@ -194,6 +194,7 @@ impl<'a, 'b> Iterator for HelpItemsIter<'a, 'b> {
     }
 }
 
+#[cfg(feature = "manpage")]
 impl<'a> HelpItems<'a> {
     pub(crate) fn flgs(&'_ self) -> impl Iterator<Item = &'_ HelpItem<'a>> + '_ {
         HelpItemsIter {
@@ -221,7 +222,9 @@ impl<'a> HelpItems<'a> {
             block: Block::No,
         }
     }
+}
 
+impl<'a> HelpItems<'a> {
     fn write_items(&self, target: HiTy) -> String {
         let mut buf = Buffer::default();
         let mut dedup_cache: BTreeSet<String> = BTreeSet::new();

--- a/src/params.rs
+++ b/src/params.rs
@@ -154,10 +154,11 @@ impl NamedArg {
     }
 }
 
-/// A flag/switch/argument that has a short name
+/// Parse a [`flag`](NamedArg::flag)/[`switch`](NamedArg::switch)/[`argument`](NamedArg::argument) that has a short name
 ///
-/// You can specify it multiple times, `bpaf` would use items past the first of each `short` and `long` as
-/// hidden aliases.
+/// You can chain multiple of [`short`](NamedArg::short), [`long`](NamedArg::long) and
+/// [`env`](NamedArg::env) for multiple names. You can specify multiple names of the same type,
+///  `bpaf` would use items past the first one as hidden aliases.
 ///
 #[doc = include_str!("docs/short_long_env.md")]
 #[must_use]
@@ -170,10 +171,11 @@ pub fn short(short: char) -> NamedArg {
     }
 }
 
-/// A flag/switch/argument that has a long name
+/// Parse a [`flag`](NamedArg::flag)/[`switch`](NamedArg::switch)/[`argument`](NamedArg::argument) that has a long name
 ///
-/// You can specify it multiple times, `bpaf` would use items past the first of each `short` and `long` as
-/// hidden aliases.
+/// You can chain multiple of [`short`](NamedArg::short), [`long`](NamedArg::long) and
+/// [`env`](NamedArg::env) for multiple names. You can specify multiple names of the same type,
+///  `bpaf` would use items past the first one as hidden aliases.
 ///
 #[doc = include_str!("docs/short_long_env.md")]
 #[must_use]
@@ -186,11 +188,11 @@ pub fn long(long: &'static str) -> NamedArg {
     }
 }
 
-/// Environment variable fallback
+/// Parse an environment variable
 ///
-/// If named value isn't present - try to fallback to this environment variable.
-///
-/// You can specify it multiple times, `bpaf` would use items past the first one as hidden aliases.
+/// You can chain multiple of [`short`](NamedArg::short), [`long`](NamedArg::long) and
+/// [`env`](NamedArg::env) for multiple names. You can specify multiple names of the same type,
+///  `bpaf` would use items past the first one as hidden aliases.
 ///
 /// For [`flag`](NamedArg::flag) and [`switch`](NamedArg::switch) environment variable being present
 /// gives the same result as the flag being present, allowing to implement things like `NO_COLOR`
@@ -387,7 +389,7 @@ impl NamedArg {
     }
 }
 
-/// Positional argument in utf8 (`String`) encoding
+/// Parse a positional argument
 ///
 /// For named flags and arguments ordering generally doesn't matter: most programs would
 /// understand `-O2 -v` the same way as `-v -O2`, but for positional items order matters: in unix
@@ -429,7 +431,7 @@ pub fn positional<T>(metavar: &'static str) -> ParsePositional<T> {
     build_positional(metavar)
 }
 
-/// Subcommand parser
+/// Parse a subcommand
 ///
 /// Subcommands allow to use a totally independent parser inside a current one. Inner parser
 /// can have its own help message, description, version and so on. You can nest them arbitrarily
@@ -993,10 +995,11 @@ pub struct ParseAny<T, I, F> {
     anywhere: bool,
 }
 
-/// Take an arbitrary unconsumed item on the command line as parsed with [`FromStr`] or raw [`String`]/[`OsString`] value.
+/// Parse a single arbitrary item from a command line
 ///
-/// **`any` is designed to consume items that don't fit into usual `flag`/`switch`/`positional`
-/// /`argument`/`command` classification**
+/// **`any` is designed to consume items that don't fit into usual [`flag`](NamedArg::flag)
+/// /[`switch`](NamedArg::switch)/[`argument`](NamedArg::argument)/[`positional`]
+/// [`command`] classification, in most cases you don't need to use it**
 ///
 /// By default `any` behaves similar to [`positional`] so you should be using it near the right
 /// most end of the consumer struct. It is possible to lift this restriction by calling

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -738,8 +738,8 @@ impl<T> ParseCon<T> {
     /// `adjacent` parser, you can restrict it *outside*, once `adjacent` done the parsing.
     ///
     /// `adjacent` is available on a trait for better discoverability, it doesn't make much sense to
-    /// use it on something other than [`command`](OptionParser::command) or [`construct!`] encasing
-    /// several fields.
+    /// use it on something other than [`command`](crate::OptionParser::command) or [`construct!`](crate::construct!)
+    /// encasing several fields.
     ///
     /// There's also similar method [`adjacent`](crate::parsers::ParseArgument) that allows to restrict argument
     /// parser to work only for arguments where both key and a value are in the same shell word:


### PR DESCRIPTION
### Breaking changes

- `any` now takes a function that checks if it matches the input or not.
  You can still apply usual filtering with `guard`, etc after it but initial
  filtering inside a function leads to better error messages.
- `anywhere` is now a method on `any` instead of being a parser method
  and should now be used to make an arbitrary looking flag like parsers.
  You can still parse blocks from arbitrary places using remaining `adjacent`
  method
- `many` and `some` will now collect one result from a parser
  that does not consume anything from an argument list allowing
  for easier composition with parsers that consume from both
  command line and environment variables. If your code depends on
  the original behavior you should replace non failing parsers under
  `many` with failing parsers: `req_flag` instead of `switch`.


### Improvements

- parsing combinators `many`, `some`, `optional` and `anywhere` will
  now propagate parsing errors outwards, you can regain the old
  behvior by specifying `catch`
- better error messages related to `anywhere` parsers
- `anywhere` parsers are now given an attempt to consume an empty list
- support deriving `req_flag` consumers
- support deriving `catch` annotation
- errors generated by `some` can now be handled with `fallback`/`fallback_with`
- fallback values can be made visible in `--help` with `display_fallback`/`debug_fallback`
- `bpaf_derive`: top level doc comments on a regular parser are now turned into a `group_help`
- better error messages for invalid user input
- env fallback can now be fully hidden
- meta description refactor - invididual parsers should be described more consistently
  in all sorts of messages
- better error messages with positionals and inside anywhere blocks


### Migration guide 0.7.x -> 0.8.x
1. if you used `any` to consume items without validations just pass `Some` as a parameter
   and add two wildcard generic type parameters:
    ```diff
    -let rest = any<OsString>("RESt").many();
    +let rest = any<OsString, _, _>("REST", Some);
    ```
2. If you used `any` with extra validation to decide if something should be consumed at all
   you can move this validation inside of any. If validation fails - any behaves as if this
   argument wasn't specified at all:
   ```diff
   -let name = any("NAME").guard(|x| x == "Bob", "Only Bob is allowed").optional().catch();
   +let name = any("NAME", |x| (x == "Bob").then_some(x));
   ```
3. You can replicate most of the behavior from old `anywhere` modifier with new `adjacent`:
   ```diff
   -let set = construct!(set, name, value).anywhere();
   +let set = construct!(set, name, value).adjacent();
   ```
4. If you previously used `switch` or an option with fallback in combination with `many`
   you need to replace `switch` with something that needs at least one item and move fallback
   outside:
   ```diff
   -let verbose = short('v').switch().many().map(|x| x.len());
   +let verbose = short('v').req_flag(()).many().map(|x| x.len());
   ```
