### PR TITLE
Improve error messages a bit more

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -595,7 +595,6 @@ impl<T> Parser<T> for ParseCommand<T> {
                 args.set_scope(cur..args.scope().end);
             }
 
-            args.head = usize::MAX;
             args.depth += 1;
             if !self.adjacent {
                 self.subparser

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,6 +1,43 @@
 use bpaf::*;
 
 #[test]
+fn this_or_that_odd() {
+    let a = short('a').req_flag(());
+    let b = short('b').req_flag(());
+    let ab = construct!(a, b);
+    let a = short('a').req_flag(());
+    let c = short('c').req_flag(());
+    let cd = construct!(a, c);
+    let parser = construct!([ab, cd]).to_options();
+
+    let res = parser
+        .run_inner(Args::from(&["-a", "-b", "-c"]))
+        .unwrap_err()
+        .unwrap_stderr();
+    assert_eq!(res, "\"-c\" cannot be used at the same time as \"-b\"");
+}
+
+#[test]
+fn cannot_be_used_partial_arg() {
+    let a = short('a').req_flag(10);
+    let b = short('b').argument::<usize>("ARG");
+    let parser = construct!([a, b]).to_options();
+
+    // TODO - error message can be improved...
+    let res = parser
+        .run_inner(Args::from(&["-b", "-a"]))
+        .unwrap_err()
+        .unwrap_stderr();
+    assert_eq!(res, "-b is not expected in this context");
+
+    let res = parser
+        .run_inner(Args::from(&["-a", "-b"]))
+        .unwrap_err()
+        .unwrap_stderr();
+    assert_eq!(res, "-b is not expected in this context");
+}
+
+#[test]
 fn better_error_with_enum() {
     #[derive(Debug, Clone, Bpaf)]
     #[bpaf(options)]


### PR DESCRIPTION
Pick the first mismatch in case of mutually exclusive branches instead of first parsed element.