### PR TITLE
Release 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -14,7 +14,7 @@ exclude = [".github/workflows", "tarp.sh"]
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.4.0", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.4.1", optional = true }
 owo-colors = { version = "3.5.0", features = ["supports-colors"], optional = true }
 roff = { version = "0.2.1", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## bpaf [0.8.1], bpaf_derive [0.4.1] - 2023-05-30
+- combination of `command` and `hide` now works as expected in `bpaf_derive`
+
 ## bpaf [0.8.0], bpaf_derive [0.4.0] - 2023-05-10
 
 ### Breaking changes

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"

--- a/bpaf_derive/src/top_tests.rs
+++ b/bpaf_derive/src/top_tests.rs
@@ -397,6 +397,38 @@ fn version_with_commands() {
 }
 
 #[test]
+fn hidden_command() {
+    let top: Top = parse_quote! {
+        #[bpaf(options)]
+        enum Action {
+            #[bpaf(command)]
+            Visible,
+            #[bpaf(command, hide)]
+            Hidden,
+        }
+    };
+    let expected = quote! {
+        fn action() -> ::bpaf::OptionParser<Action> {
+            #[allow(unused_imports)]
+            use ::bpaf::Parser;
+            {
+                let alt0 = {
+                    let inner_cmd = ::bpaf::pure(Action::Visible).to_options();
+                    ::bpaf::command("visible", inner_cmd)
+                };
+                let alt1 = {
+                    let inner_cmd = ::bpaf::pure(Action::Hidden).to_options();
+                    ::bpaf::command("hidden", inner_cmd)
+                }.hide();
+                ::bpaf::construct!([alt0, alt1])
+            }
+            .to_options()
+        }
+    };
+    assert_eq!(top.to_token_stream().to_string(), expected.to_string());
+}
+
+#[test]
 fn command_with_aliases() {
     let top: Top = parse_quote! {
         #[bpaf(command, short('c'), long("long"))]


### PR DESCRIPTION

- combination of `command` and `hide` now works as expected in `bpaf_derive`