### PR TITLE
Prepare to release 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -19,7 +19,7 @@ include = [
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.5.0", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.5.1", optional = true }
 owo-colors = { version = "3.5.0", default-features = false, optional = true }
 supports-color = { version = "2.0.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## bpaf [0.9.1] - 2023-07-04, bpaf_derive [0.5.1]
+- add a way to print usage when called with no argument_os
+- since 0.9.0 bpaf splits help messages into "full" and "partial", displaying
+  full only when `--help` flag is passed twice or when rendering the documentation,
+  see https://docs.rs/bpaf/0.9.0/bpaf/parsers/struct.NamedArg.html#method.help
+- regression fixes
 
 ## bpaf [0.9.0] - 2023-07-03
 - more errors are now passed as ADTs rather than plain strings

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -73,6 +73,6 @@ fn opts() -> OptionParser<Out> {
 }
 
 fn main() {
-    let opts = opts().run();
+    let opts = opts().fallback_to_usage().run();
     println!("{:#?}", opts);
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -185,7 +185,7 @@ pub use inner::State;
 mod inner {
     use std::{ops::Range, rc::Rc};
 
-    use crate::{error::Message, Args};
+    use crate::{error::Message, parsers::NamedArg, Args};
 
     use super::{split_os_argument, Arg, ArgType, ItemState};
     #[derive(Clone, Debug)]
@@ -255,6 +255,7 @@ mod inner {
             short_flags: &[char],
             short_args: &[char],
             err: &mut Option<Message>,
+            help: Option<&NamedArg>,
         ) -> State {
             let mut items = Vec::new();
             let mut pos_only = false;
@@ -356,6 +357,15 @@ mod inner {
                             Arg::Word(os)
                         });
                     }
+                }
+            }
+            if items.is_empty() {
+                if let Some(help) = help.and_then(|h| h.long.first()) {
+                    items.push(Arg::Long(
+                        (*help).to_owned(),
+                        false,
+                        std::ffi::OsString::new(),
+                    ))
                 }
             }
 
@@ -717,7 +727,7 @@ mod tests {
         fn from(value: &'static [&'static str; N]) -> Self {
             let args = Args::from(value);
             let mut msg = None;
-            let res = State::construct(args, &[], &[], &mut msg);
+            let res = State::construct(args, &[], &[], &mut msg, None);
             if let Some(err) = &msg {
                 panic!("Couldn't construct state: {:?}/{:?}", err, res);
             }
@@ -747,7 +757,7 @@ mod tests {
     fn multiple_short_flags() {
         let args = Args::from(&["-vvv"]);
         let mut err = None;
-        let mut a = State::construct(args, &['v'], &[], &mut err);
+        let mut a = State::construct(args, &['v'], &[], &mut err, None);
         assert!(a.take_flag(&short('v')));
         assert!(a.take_flag(&short('v')));
         assert!(a.take_flag(&short('v')));
@@ -871,7 +881,7 @@ mod tests {
     fn ambiguity_towards_flag() {
         let args = Args::from(&["-abc"]);
         let mut err = None;
-        let mut a = State::construct(args, &['a', 'b', 'c'], &[], &mut err);
+        let mut a = State::construct(args, &['a', 'b', 'c'], &[], &mut err, None);
 
         assert!(a.take_flag(&short('a')));
         assert!(a.take_flag(&short('b')));
@@ -882,7 +892,7 @@ mod tests {
     fn ambiguity_towards_argument() {
         let args = Args::from(&["-abc"]);
         let mut err = None;
-        let mut a = State::construct(args, &[], &['a'], &mut err);
+        let mut a = State::construct(args, &[], &['a'], &mut err, None);
 
         let r = a.take_arg(&short('a'), false, M).unwrap().unwrap();
         assert_eq!(r, "bc");
@@ -892,7 +902,7 @@ mod tests {
     fn ambiguity_towards_error() {
         let args = Args::from(&["-abc"]);
         let mut err = None;
-        let _a = State::construct(args, &['a', 'b', 'c'], &['a'], &mut err);
+        let _a = State::construct(args, &['a', 'b', 'c'], &['a'], &mut err, None);
         assert!(err.is_some());
     }
 


### PR DESCRIPTION
Mostly regression fixes, but you can now use `fallback_to_usage` if you want to print the usage when user specifies no arguments

```rust
options().fallback_to_usage().run()
```

