### PR TITLE
feat: markdown rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 /tarp
 /dotfiles
 /legacy/target
+.idea

--- a/src/buffer/html.rs
+++ b/src/buffer/html.rs
@@ -27,13 +27,13 @@ fn collect_html(app: String, meta: &Meta, info: &Info) -> Doc {
         // TODO - this defines forward references to sections which are rendered differently
         // between html and markdown and never used in console...
         for section in &sections {
-            buf.token(Token::BlockStart(Block::Block));
+            buf.token(Token::BlockStart(Block::ItemBody));
             buf.text(&format!(
                 "* [`{}`↴](#{})",
                 section.path.join(" "),
-                section.path.join("-").to_lowercase(),
+                section.path.join("-").to_lowercase().replace(' ', "-"),
             ));
-            buf.token(Token::BlockEnd(Block::Block));
+            buf.token(Token::BlockEnd(Block::ItemBody));
         }
     }
 
@@ -54,7 +54,6 @@ fn collect_html(app: String, meta: &Meta, info: &Info) -> Doc {
     buf
 }
 
-
 impl<T> OptionParser<T> {
     /// Render command line documentation for the app into html/markdown mix
     pub fn render_html(&self, app: impl Into<String>) -> String {
@@ -63,7 +62,7 @@ impl<T> OptionParser<T> {
 
     /// Render command line documentation for the app into Markdown
     pub fn render_markdown(&self, app: impl Into<String>) -> String {
-        collect_html(app.into(), &self.inner.meta(), &self.info).render_markdown(true, false)
+        collect_html(app.into(), &self.inner.meta(), &self.info).render_markdown(true)
     }
 }
 
@@ -124,32 +123,46 @@ fn change_style(res: &mut String, cur: &mut Styles, new: Styles) {
 
 fn change_to_markdown_style(res: &mut String, cur: &mut Styles, new: Styles) {
     if cur.mono {
-        res.push_str("`");
+        res.push('`');
     }
 
     if cur.bold {
         res.push_str("**");
     }
     if cur.italic {
-        res.push_str("_");
+        res.push('_');
     }
     if new.italic {
-        res.push_str("_");
+        res.push('_');
     }
     if new.bold {
         res.push_str("**");
     }
 
     if new.mono {
-        res.push_str("`");
+        res.push('`');
     }
     *cur = new;
 }
 
 /// Make it so new text is separated by an empty line
-fn blank_line(res: &mut String) {
+fn blank_html_line(res: &mut String) {
     if !(res.is_empty() || res.ends_with("<br>\n")) {
         res.push_str("<br>\n");
+    }
+}
+
+/// Make it so new text is separated by an empty line
+fn blank_markdown_line(res: &mut String) {
+    if !(res.is_empty() || res.ends_with("\n\n")) {
+        res.push_str("\n\n");
+    }
+}
+
+/// Make it so new text is separated by an empty line
+fn new_markdown_line(res: &mut String) {
+    if !(res.is_empty() || res.ends_with("\n")) {
+        res.push_str("\n");
     }
 }
 
@@ -176,8 +189,14 @@ impl Doc {
         let mut byte_pos = 0;
         let mut cur_style = Styles::default();
 
+        // skip tracks text paragraphs, paragraphs starting from the section
+        // one are only shown when full is set to true
         let mut skip = Skip::default();
+
+        // stack keeps track of the AST tree, mostly to be able to tell
+        // if we are rendering definition list or item list
         let mut stack = Vec::new();
+
         for token in self.tokens.iter().copied() {
             match token {
                 Token::Text { bytes, style } => {
@@ -212,7 +231,7 @@ impl Doc {
                     change_style(&mut res, &mut cur_style, Styles::default());
                     match b {
                         Block::Header => {
-                            blank_line(&mut res);
+                            blank_html_line(&mut res);
                             res.push_str("# ");
                         }
                         Block::Section2 => {
@@ -246,7 +265,7 @@ impl Doc {
                     stack.pop();
                     match b {
                         Block::Header => {
-                            blank_line(&mut res);
+                            blank_html_line(&mut res);
                         }
                         Block::Section2 => {
                             res.push_str("</div>");
@@ -281,17 +300,17 @@ impl Doc {
         res
     }
 
-
     /// Render doc into markdown document, used by documentation sample generator
     #[must_use]
-    pub fn render_markdown(&self, full: bool, include_css: bool) -> String {
+    pub fn render_markdown(&self, full: bool) -> String {
         let mut res = String::new();
         let mut byte_pos = 0;
         let mut cur_style = Styles::default();
 
         let mut skip = Skip::default();
         let mut stack = Vec::new();
-        for token in self.tokens.iter().copied() {
+        let mut empty_term = false;
+        for (ix, token) in self.tokens.iter().copied().enumerate() {
             match token {
                 Token::Text { bytes, style } => {
                     let input = &self.payload[byte_pos..byte_pos + bytes];
@@ -310,13 +329,13 @@ impl Doc {
                             }
                             Chunk::Paragraph => {
                                 if full {
-                                    res.push_str("\n");
+                                    res.push('\n');
                                 } else {
                                     skip.enable();
                                     break;
                                 }
                             }
-                            Chunk::LineBreak => res.push_str("\n"),
+                            Chunk::LineBreak => res.push('\n'),
                         }
                     }
                 }
@@ -324,25 +343,27 @@ impl Doc {
                     change_to_markdown_style(&mut res, &mut cur_style, Styles::default());
                     match b {
                         Block::Header => {
-                            blank_line(&mut res);
+                            blank_markdown_line(&mut res);
                             res.push_str("# ");
                         }
                         Block::Section2 => {
                             res.push_str("");
                         }
-                        Block::ItemTerm => res.push_str("- "),
+                        Block::ItemTerm => {
+                            empty_term = matches!(
+                                self.tokens.get(ix + 1),
+                                Some(Token::BlockEnd(Block::ItemTerm))
+                            );
+                            res.push_str(if empty_term { "  " } else { "- " });
+                        }
                         Block::ItemBody => {
-                            if stack.last().copied() == Some(Block::DefinitionList) {
-                                res.push_str("");
-                            } else {
-                                res.push_str("");
-                            }
+                            new_markdown_line(&mut res);
                         }
                         Block::DefinitionList => {
                             res.push_str("");
                         }
                         Block::Block => {
-                            res.push_str("\n");
+                            res.push('\n');
                         }
                         Block::Meta => todo!(),
                         Block::Section3 => res.push_str("### "),
@@ -357,45 +378,35 @@ impl Doc {
                     change_to_markdown_style(&mut res, &mut cur_style, Styles::default());
                     stack.pop();
                     match b {
-                        Block::Header => {
-                            res.push_str("\n")
-                        }
+                        Block::Header => res.push('\n'),
                         Block::Section2 => {
-                            res.push_str("\n");
+                            res.push('\n');
                         }
 
                         Block::InlineBlock => {
                             skip.pop();
                         }
-                        Block::ItemTerm => res.push_str(": "),
+                        Block::ItemTerm => res.push_str(if empty_term { " " } else { " &mdash; " }),
                         Block::ItemBody => {
                             if stack.last().copied() == Some(Block::DefinitionList) {
-                                res.push_str("\n");
-                            } else {
-                                res.push_str("");
+                                res.push('\n');
                             }
                         }
-                        Block::DefinitionList => res.push_str("\n"),
+                        Block::DefinitionList => res.push('\n'),
                         Block::Block => {
-                            res.push_str("\n");
+                            res.push('\n');
                         }
                         Block::Meta => todo!(),
                         Block::TermRef => {}
-                        Block::Section3 => res.push_str("\n"),
+                        Block::Section3 => res.push('\n'),
                     }
                 }
             }
         }
         change_to_markdown_style(&mut res, &mut cur_style, Styles::default());
-        if include_css {
-            res.push_str(CSS);
-        }
         res
     }
-
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/buffer/html.rs
+++ b/src/buffer/html.rs
@@ -161,8 +161,8 @@ fn blank_markdown_line(res: &mut String) {
 
 /// Make it so new text is separated by an empty line
 fn new_markdown_line(res: &mut String) {
-    if !(res.is_empty() || res.ends_with("\n")) {
-        res.push_str("\n");
+    if !(res.is_empty() || res.ends_with('\n')) {
+        res.push('\n');
     }
 }
 
@@ -323,10 +323,7 @@ impl Doc {
 
                     for chunk in split(input) {
                         match chunk {
-                            Chunk::Raw(input, _) => {
-                                let input = input.replace('<', "&lt;").replace('>', "&gt;");
-                                res.push_str(&input);
-                            }
+                            Chunk::Raw(input, _) => res.push_str(input),
                             Chunk::Paragraph => {
                                 if full {
                                     res.push('\n');

--- a/tests/markdown.md
+++ b/tests/markdown.md
@@ -9,7 +9,7 @@ Sometimes they even work.
 **Available options:**
 - **`-d`**, **`--kraken`**: Unleash the kraken
 - **`    --user`**=_`USER`_: Log in as this user
-- : Uses environment variable **`USER`**
+    Uses environment variable **`USER`**
 - **`-h`**, **`--help`**: Prints help information
 
 

--- a/tests/markdown.md
+++ b/tests/markdown.md
@@ -1,0 +1,17 @@
+# simple
+
+I am a program and I do things
+
+**Usage**: **`simple`** [**`-d`**] **`--user`**=_`USER`_
+
+Sometimes they even work.
+
+**Available options:**
+- **`-d`**, **`--kraken`**: Unleash the kraken
+- **`    --user`**=_`USER`_: Log in as this user
+- : Uses environment variable **`USER`**
+- **`-h`**, **`--help`**: Prints help information
+
+
+
+Beware `-d`, dragons be here

--- a/tests/markdown.md
+++ b/tests/markdown.md
@@ -7,10 +7,14 @@ I am a program and I do things
 Sometimes they even work.
 
 **Available options:**
-- **`-d`**, **`--kraken`**: Unleash the kraken
-- **`    --user`**=_`USER`_: Log in as this user
-    Uses environment variable **`USER`**
-- **`-h`**, **`--help`**: Prints help information
+- **`-d`**, **`--kraken`** &mdash; 
+Unleash the kraken
+- **`    --user`**=_`USER`_ &mdash; 
+Log in as this user
+   
+Uses environment variable **`USER`**
+- **`-h`**, **`--help`** &mdash; 
+Prints help information
 
 
 

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -1,0 +1,47 @@
+use bpaf::*;
+
+fn write_updated(new_val: &str, path: impl AsRef<std::path::Path>) -> std::io::Result<bool> {
+    use std::io::Read;
+    use std::io::Seek;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .read(true)
+        .create(true)
+        .open(path)?;
+    let mut current_val = String::new();
+    file.read_to_string(&mut current_val)?;
+    if current_val != new_val {
+        file.set_len(0)?;
+        file.seek(std::io::SeekFrom::Start(0))?;
+        std::io::Write::write_all(&mut file, new_val.as_bytes())?;
+        Ok(false)
+    } else {
+        Ok(true)
+    }
+}
+
+
+#[test]
+fn simple() {
+    let kraken = short('d')
+        .long("kraken")
+        .help("Unleash the kraken")
+        .switch();
+
+    let user = long("user")
+        .env("USER")
+        .help("Log in as this user")
+        .argument::<String>("USER");
+
+    let options = construct!(kraken, user)
+        .to_options()
+        .descr("I am a program and I do things")
+        .header("Sometimes they even work.")
+        .footer("Beware `-d`, dragons be here");
+    let roff = options.render_markdown(
+        "simple",
+    );
+
+    #[cfg(unix)]
+    assert!(write_updated(&roff, "tests/markdown.md").unwrap());
+}

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -20,7 +20,6 @@ fn write_updated(new_val: &str, path: impl AsRef<std::path::Path>) -> std::io::R
     }
 }
 
-
 #[test]
 fn simple() {
     let kraken = short('d')
@@ -38,9 +37,7 @@ fn simple() {
         .descr("I am a program and I do things")
         .header("Sometimes they even work.")
         .footer("Beware `-d`, dragons be here");
-    let roff = options.render_markdown(
-        "simple",
-    );
+    let roff = options.render_markdown("simple");
 
     #[cfg(unix)]
     assert!(write_updated(&roff, "tests/markdown.md").unwrap());


### PR DESCRIPTION
I noticed that now the documentation can be emitted in HTML, so I thought also to have a markdown format.

The code is mostly a copy-paste of the render of the HTML, but I'm happy to refactor it with some direction. Ideally, we could move it to a `markdown.rs` file.


Leaving it as a draft at the moment, asking the following questions:
- I couldn't find a proper way to test the doc gen, so I just copied the manpage test for a POC
- the environment variable is rendered strangely, probably because it has different metadata; how do you suggest tackling this part?
- what kind of test cases would you like to add?