### PR TITLE
Use a full sentence to report error messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## bpaf [0.9.2], bpaf_derive [0.5.2] - Unreleased
 - with `docgen` feature you can render documentation as markdown
+- cosmetic changes to error messages
 
 ## bpaf [0.9.1], bpaf_derive [0.5.1] - 2023-07-05
 - add a way to print usage when called with no argument_os

--- a/docs2/src/lib.rs
+++ b/docs2/src/lib.rs
@@ -93,7 +93,7 @@ $ app {all_args}<br>
             "
 <div class='bpaf-doc'>
 $ app {all_args}<br>
-{}
+<b>Error:</b> {}
 </div>
 ",
             buf.render_html(true, true)

--- a/src/buffer/console.rs
+++ b/src/buffer/console.rs
@@ -91,7 +91,7 @@ impl Default for Color {
 
 #[cfg(feature = "color")]
 impl Color {
-    fn push_str(self, style: Style, res: &mut String, item: &str) {
+    pub(crate) fn push_str(self, style: Style, res: &mut String, item: &str) {
         use owo_colors::OwoColorize;
         use std::fmt::Write;
         match self {

--- a/src/buffer/splitter.rs
+++ b/src/buffer/splitter.rs
@@ -5,6 +5,7 @@ pub(super) struct Splitter<'a> {
     code: Code,
 }
 
+#[cfg(feature = "docgen")]
 enum Code {
     No,
     First,

--- a/src/docs2/adjacent_argument.md
+++ b/src/docs2/adjacent_argument.md
@@ -65,7 +65,7 @@ As with regular [`argument`](NamedArg::argument) its `adjacent` variant is requi
 
 <div class='bpaf-doc'>
 $ app <br>
-Expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -101,7 +101,7 @@ Separating them by space results in parse failure
 
 <div class='bpaf-doc'>
 $ app --package htb<br>
-Expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, got <b>--package</b>. Pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, got <b>--package</b>. Pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -119,7 +119,7 @@ div.bpaf-doc  { padding-left: 1em; }
 
 <div class='bpaf-doc'>
 $ app -p htb<br>
-Expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, got <b>-p</b>. Pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, got <b>-p</b>. Pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -137,7 +137,7 @@ div.bpaf-doc  { padding-left: 1em; }
 
 <div class='bpaf-doc'>
 $ app --package<br>
-Expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, got <b>--package</b>. Pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--package</b></tt>=<tt><i>SPEC</i></tt>, got <b>--package</b>. Pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/adjacent_command.md
+++ b/src/docs2/adjacent_command.md
@@ -183,7 +183,7 @@ adjacent
 
 <div class='bpaf-doc'>
 $ app sleep --time 10 eat --premium 'Bak Kut Teh' drink<br>
-Expected <tt><i>FOOD</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><i>FOOD</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/adjacent_struct_0.md
+++ b/src/docs2/adjacent_struct_0.md
@@ -131,7 +131,7 @@ Options { point: [Point { point: (), x: 10, y: 20, z: 3.1415 }, Point { point: (
 
 <div class='bpaf-doc'>
 $ app --point 10 20 --rotate 3.1415<br>
-Expected <tt><i>Z</i></tt>, got <b>--rotate</b>. Pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><i>Z</i></tt>, got <b>--rotate</b>. Pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/adjacent_struct_1.md
+++ b/src/docs2/adjacent_struct_1.md
@@ -137,7 +137,7 @@ But with `adjacent` they cannot interleave
 
 <div class='bpaf-doc'>
 $ app --rect --rect --width 10 --painted --height 10 --height 10 --width 10<br>
-Expected <tt><b>--width</b></tt>=<tt><i>PX</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--width</b></tt>=<tt><i>PX</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -157,7 +157,7 @@ Or have items that don't belong to the group inside them
 
 <div class='bpaf-doc'>
 $ app --rect --width 10 --mirror --painted --height 10 --rect --height 10 --width 10<br>
-Expected <tt><b>--height</b></tt>=<tt><i>PX</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--height</b></tt>=<tt><i>PX</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/adjacent_struct_3.md
+++ b/src/docs2/adjacent_struct_3.md
@@ -134,7 +134,7 @@ optional.
 
 <div class='bpaf-doc'>
 $ app --exec ;<br>
-<b>--exec</b> is not expected in this context
+<b>Error:</b> <b>--exec</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/adjacent_struct_4.md
+++ b/src/docs2/adjacent_struct_4.md
@@ -125,7 +125,7 @@ Error messages should be somewhat descriptive
 
 <div class='bpaf-doc'>
 $ app --meal --drink --spicy 500<br>
-Expected <tt><i>DISH</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><i>DISH</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/any_literal.md
+++ b/src/docs2/any_literal.md
@@ -167,7 +167,7 @@ Output file is required in this parser, other values are optional
 
 <div class='bpaf-doc'>
 $ app <br>
-Expected <tt><b>of=</b></tt><tt><i>FILE</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>of=</b></tt><tt><i>FILE</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/any_switch.md
+++ b/src/docs2/any_switch.md
@@ -169,7 +169,7 @@ doesn't really knows what the function inside `any` is going to consume
 
 <div class='bpaf-doc'>
 $ app --turbo -xinerama +backin<br>
-<b>+backin</b> is not expected in this context
+<b>Error:</b> <b>+backin</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/argument.md
+++ b/src/docs2/argument.md
@@ -123,7 +123,7 @@ stops and argument begins:
 
 <div class='bpaf-doc'>
 $ app --age12<br>
-No such flag: <b>--age12</b>, did you mean <tt><b>--age</b></tt>?
+<b>Error:</b> no such flag: <b>--age12</b>, did you mean <tt><b>--age</b></tt>?
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -144,7 +144,7 @@ Either way - value is required, passing just the argument name results in parse 
 
 <div class='bpaf-doc'>
 $ app --name<br>
-<tt><b>--name</b></tt> requires an argument <tt><i>NAME</i></tt>
+<b>Error:</b> <tt><b>--name</b></tt> requires an argument <tt><i>NAME</i></tt>
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/custom_help_version.md
+++ b/src/docs2/custom_help_version.md
@@ -91,7 +91,7 @@ and old short name no longer works.
 
 <div class='bpaf-doc'>
 $ app -h<br>
-<b>-h</b> is not expected in this context
+<b>Error:</b> <b>-h</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/fallback.md
+++ b/src/docs2/fallback.md
@@ -56,7 +56,7 @@ Parsing errors are preserved and preserved to user
 
 <div class='bpaf-doc'>
 $ app --jobs ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/fallback_with.md
+++ b/src/docs2/fallback_with.md
@@ -64,7 +64,7 @@ Parsing errors are preserved and preserved to user
 
 <div class='bpaf-doc'>
 $ app --version ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/guard.md
+++ b/src/docs2/guard.md
@@ -77,7 +77,7 @@ And fails with the error message on higher values:
 
 <div class='bpaf-doc'>
 $ app --number 11<br>
-<b>11</b>: Values greater than 10 are only available in the DLC pack!
+<b>Error:</b> <b>11</b>: Values greater than 10 are only available in the DLC pack!
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -100,7 +100,7 @@ in some way
 
 <div class='bpaf-doc'>
 $ app --number ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/many_catch.md
+++ b/src/docs2/many_catch.md
@@ -130,7 +130,7 @@ In case of wrong `--width` - parser `width` fails, parser for `many` sees this a
 
 <div class='bpaf-doc'>
 $ app --width ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/map.md
+++ b/src/docs2/map.md
@@ -50,7 +50,7 @@ in some way. In fact here execution never reaches `map` function -
 
 <div class='bpaf-doc'>
 $ app --number ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/named_arg_combine.md
+++ b/src/docs2/named_arg_combine.md
@@ -95,7 +95,7 @@ valid _visible_ argument
 
 <div class='bpaf-doc'>
 $ app -o best.txt -s 10 --verbos<br>
-No such flag: <b>--verbos</b>, did you mean <tt><b>--verbose</b></tt>?
+<b>Error:</b> no such flag: <b>--verbos</b>, did you mean <tt><b>--verbose</b></tt>?
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -116,7 +116,7 @@ It will not do so for hidden aliases
 
 <div class='bpaf-doc'>
 $ app -o best.txt -s 10 --detaile<br>
-<b>--detaile</b> is not expected in this context
+<b>Error:</b> <b>--detaile</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -158,7 +158,7 @@ If neither is present - it fails - parser for `output` expects one of its branch
 
 <div class='bpaf-doc'>
 $ app -s 330<br>
-Expected <tt><b>--output</b></tt>=<tt><i>PATH</i></tt> or <tt><b>--output</b></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--output</b></tt>=<tt><i>PATH</i></tt> or <tt><b>--output</b></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/named_arg_derive.md
+++ b/src/docs2/named_arg_derive.md
@@ -116,7 +116,7 @@ valid _visible_ argument
 
 <div class='bpaf-doc'>
 $ app --database default --quie<br>
-No such flag: <b>--quie</b>, did you mean <tt><b>--quiet</b></tt>?
+<b>Error:</b> no such flag: <b>--quie</b>, did you mean <tt><b>--quiet</b></tt>?
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -137,7 +137,7 @@ It will not do so for hidden aliases
 
 <div class='bpaf-doc'>
 $ app --database default --essentia<br>
-<b>--essentia</b> is not expected in this context
+<b>Error:</b> <b>--essentia</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/optional_catch.md
+++ b/src/docs2/optional_catch.md
@@ -130,7 +130,7 @@ In case of wrong `--width` - parser `width` fails, parser for `optional` sees th
 
 <div class='bpaf-doc'>
 $ app --width ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/parse.md
+++ b/src/docs2/parse.md
@@ -77,7 +77,7 @@ in some other way
 
 <div class='bpaf-doc'>
 $ app --number ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/positional.md
+++ b/src/docs2/positional.md
@@ -141,7 +141,7 @@ Without using `--` `bpaf` would only accept items that don't start with `-` as p
 
 <div class='bpaf-doc'>
 $ app --detailed<br>
-Expected <tt><i>CRATE</i></tt>, got <b>--detailed</b>. Pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><i>CRATE</i></tt>, got <b>--detailed</b>. Pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -159,7 +159,7 @@ div.bpaf-doc  { padding-left: 1em; }
 
 <div class='bpaf-doc'>
 $ app --verbose<br>
-Expected <tt><i>CRATE</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><i>CRATE</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/pure.md
+++ b/src/docs2/pure.md
@@ -75,7 +75,7 @@ Any attempts to do so would result in an error :)
 
 <div class='bpaf-doc'>
 $ app --money 100000 --name Hackerman<br>
-<b>--money</b> is not expected in this context
+<b>Error:</b> <b>--money</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/pure_with.md
+++ b/src/docs2/pure_with.md
@@ -83,7 +83,7 @@ Any attempts to do so would result in an error :)
 
 <div class='bpaf-doc'>
 $ app --money 100000 --name Hackerman<br>
-<b>--money</b> is not expected in this context
+<b>Error:</b> <b>--money</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/req_flag.md
+++ b/src/docs2/req_flag.md
@@ -143,7 +143,7 @@ Example contains two parsers that fails without any input: `agree` requires pass
 
 <div class='bpaf-doc'>
 $ app <br>
-Expected <tt><b>--agree</b></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--agree</b></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -164,7 +164,7 @@ While `style` takes one of several possible values
 
 <div class='bpaf-doc'>
 $ app --agree<br>
-Expected <tt><b>--intel</b></tt>, <tt><b>--att</b></tt>, or more, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--intel</b></tt>, <tt><b>--att</b></tt>, or more, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -196,7 +196,7 @@ While parser for `style` takes any posted output - it won't take multiple of the
 
 <div class='bpaf-doc'>
 $ app --agree --att --llvm<br>
-<tt><b>--llvm</b></tt> cannot be used at the same time as <tt><b>--att</b></tt>
+<b>Error:</b> <tt><b>--llvm</b></tt> cannot be used at the same time as <tt><b>--att</b></tt>
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/short_long_env.md
+++ b/src/docs2/short_long_env.md
@@ -118,7 +118,7 @@ you can specify them multiple times:
 
 <div class='bpaf-doc'>
 $ app -A 42 -a 330 -u Bobert<br>
-<b>-a</b> is not expected in this context
+<b>Error:</b> <b>-a</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -140,7 +140,7 @@ won't show up anywhere else in completions or error messages
 
 <div class='bpaf-doc'>
 $ app -a 42 -A 330 -u Bobert<br>
-<b>-A</b> is not expected in this context
+<b>Error:</b> <b>-A</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/some.md
+++ b/src/docs2/some.md
@@ -83,7 +83,7 @@ With not enough parameters to satisfy both parsers at least once - it fails
 
 <div class='bpaf-doc'>
 $ app <br>
-want at least one argument
+<b>Error:</b> want at least one argument
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -104,7 +104,7 @@ both parsers need to succeed to create a struct
 
 <div class='bpaf-doc'>
 $ app --argument 10<br>
-want at least one switch
+<b>Error:</b> want at least one switch
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/some_catch.md
+++ b/src/docs2/some_catch.md
@@ -99,7 +99,7 @@ one matching parameter
 
 <div class='bpaf-doc'>
 $ app <br>
-You must specify some heights
+<b>Error:</b> You must specify some heights
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -142,7 +142,7 @@ In case of wrong `--width` - parser `width` fails, parser for `some` sees this a
 
 <div class='bpaf-doc'>
 $ app --height 10 --width 33 --width ten<br>
-Couldn't parse <b>ten</b>: invalid digit found in string
+<b>Error:</b> couldn't parse <b>ten</b>: invalid digit found in string
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/switch.md
+++ b/src/docs2/switch.md
@@ -108,7 +108,7 @@ When value is present - `switch` returns `true`, `flag` returns first value.
 
 <div class='bpaf-doc'>
 $ app --verbose --no-default-features --detailed<br>
-<b>--detailed</b> is not expected in this context
+<b>Error:</b> <b>--detailed</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -130,7 +130,7 @@ command line:
 
 <div class='bpaf-doc'>
 $ app --no-default-features --no-default-features<br>
-Argument <tt><b>--no-default-features</b></tt> cannot be used multiple times in this context
+<b>Error:</b> argument <tt><b>--no-default-features</b></tt> cannot be used multiple times in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/to_options.md
+++ b/src/docs2/to_options.md
@@ -95,7 +95,7 @@ Other than that `bpaf` tries its best to provide a helpful error messages
 
 <div class='bpaf-doc'>
 $ app <br>
-Expected <tt><b>-i</b></tt>=<tt><i>ARG</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>-i</b></tt>=<tt><i>ARG</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/usage.md
+++ b/src/docs2/usage.md
@@ -77,7 +77,7 @@ It doesn't alter parser's behavior otherwise
 
 <div class='bpaf-doc'>
 $ app <br>
-Expected <tt><b>--binary</b></tt>=<tt><i>BIN</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--binary</b></tt>=<tt><i>BIN</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/with_usage.md
+++ b/src/docs2/with_usage.md
@@ -68,7 +68,7 @@ It doesn't alter parser's behavior otherwise
 
 <div class='bpaf-doc'>
 $ app <br>
-Expected <tt><b>--binary</b></tt>=<tt><i>BIN</i></tt>, pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><b>--binary</b></tt>=<tt><i>BIN</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/tests/adjacent.rs
+++ b/tests/adjacent.rs
@@ -55,7 +55,7 @@ fn adjacent_error_message_pos_single() {
     let parser = construct!(adj, d).to_options();
 
     let r = parser.run_inner(&["-a", "10"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `C`, pass `--help` for usage information");
+    assert_eq!(r, "expected `C`, pass `--help` for usage information");
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn adjacent_error_message_arg_single() {
     let r = parser.run_inner(&["-a", "10"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         r,
-        "Expected `-b=B`, got `10`. Pass `--help` for usage information"
+        "expected `-b=B`, got `10`. Pass `--help` for usage information"
     );
 }
 
@@ -84,7 +84,7 @@ fn adjacent_error_message_pos_many() {
     let parser = construct!(adj, d).to_options();
 
     let r = parser.run_inner(&["-a", "10"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `C`, pass `--help` for usage information");
+    assert_eq!(r, "expected `C`, pass `--help` for usage information");
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn adjacent_error_message_arg_many() {
     // this should ask for -b or -c and complain on 10...
     assert_eq!(
         r,
-        "Expected `-b=B`, got `10`. Pass `--help` for usage information"
+        "expected `-b=B`, got `10`. Pass `--help` for usage information"
     );
 }
 
@@ -114,7 +114,7 @@ fn adjacent_is_adjacent() {
         .run_inner(&["-a", "-a", "10", "20"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "Expected `B`, pass `--help` for usage information");
+    assert_eq!(r, "expected `B`, pass `--help` for usage information");
 
     let r = parser.run_inner(&["-a", "10", "-a", "20"]).unwrap();
     assert_eq!(r, [10, 20]);

--- a/tests/anywhere.rs
+++ b/tests/anywhere.rs
@@ -36,37 +36,37 @@ fn parse_anywhere_no_catch() {
     // Usage: -a <x> [-c],
 
     let r = parser.run_inner(&["3", "-a"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `X`, pass `--help` for usage information");
+    assert_eq!(r, "expected `X`, pass `--help` for usage information");
 
     let r = parser.run_inner(&["-a"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `X`, pass `--help` for usage information");
+    assert_eq!(r, "expected `X`, pass `--help` for usage information");
 
     let r = parser
         .run_inner(&["-a", "221b"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "Couldn't parse `221b`: invalid digit found in string");
+    assert_eq!(r, "couldn't parse `221b`: invalid digit found in string");
 
     let r = parser.run_inner(&["-c", "-a"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `X`, pass `--help` for usage information");
+    assert_eq!(r, "expected `X`, pass `--help` for usage information");
 
     let r = parser
         .run_inner(&["-c", "-a", "221b"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "Couldn't parse `221b`: invalid digit found in string");
+    assert_eq!(r, "couldn't parse `221b`: invalid digit found in string");
 
     let r = parser.run_inner(&["-a", "-c"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         r,
-        "Expected `X`, got `-c`. Pass `--help` for usage information"
+        "expected `X`, got `-c`. Pass `--help` for usage information"
     );
 
     let r = parser
         .run_inner(&["-a", "221b", "-c"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "Couldn't parse `221b`: invalid digit found in string");
+    assert_eq!(r, "couldn't parse `221b`: invalid digit found in string");
 }
 
 #[test]

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -980,7 +980,7 @@ fn suggest_double_dash_automatically_for_strictly_positional() {
 }
 
 #[test]
-#[should_panic(expected = "App supports ")]
+#[should_panic(expected = "app supports ")]
 fn ambiguity_no_resolve() {
     let a0 = short('a').switch().count();
     let a1 = short('a').argument::<usize>("AAAAAA");

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -141,19 +141,19 @@ fn cannot_be_used_twice() {
         .unwrap_stderr();
     assert_eq!(
         r,
-        "Argument `-a` cannot be used multiple times in this context"
+        "argument `-a` cannot be used multiple times in this context"
     );
 
     let r = parser.run_inner(&["-a", "-a"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         r,
-        "Argument `-a` cannot be used multiple times in this context"
+        "argument `-a` cannot be used multiple times in this context"
     );
 
     let r = parser.run_inner(&["-abba"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         r,
-        "Argument `-a` cannot be used multiple times in this context"
+        "argument `-a` cannot be used multiple times in this context"
     );
 }
 
@@ -168,13 +168,13 @@ fn should_not_split_adjacent_options() {
     let r = parser.run_inner(&["-a=hello"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         r,
-        "Expected `COMMAND ...`, got `hello`. Pass `--help` for usage information"
+        "expected `COMMAND ...`, got `hello`. Pass `--help` for usage information"
     );
 
     let r = parser.run_inner(&["-ahello"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         r,
-        "Expected `COMMAND ...`, got `hello`. Pass `--help` for usage information"
+        "expected `COMMAND ...`, got `hello`. Pass `--help` for usage information"
     );
 
     // this one is okay
@@ -189,5 +189,5 @@ fn adjacent_option_complains_to() {
     let r = parser.run_inner(&["-ayam"]).unwrap_err().unwrap_stderr();
 
     // TODO - this should point to the whole "-ayam" thing
-    assert_eq!(r, "Couldn't parse `yam`: invalid digit found in string");
+    assert_eq!(r, "couldn't parse `yam`: invalid digit found in string");
 }

--- a/tests/meta_youmean.rs
+++ b/tests/meta_youmean.rs
@@ -15,7 +15,7 @@ fn ambiguity() {
     let parser = construct!([a0, a1]).to_options();
 
     let r = parser.run_inner(&["-aaaaaa"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "App supports `-a` as both an option and an option-argument, try to split `-aaaaaa` into individual options\n(-a -a ..) or use `-a=aaaaa` syntax to disambiguate");
+    assert_eq!(r, "app supports `-a` as both an option and an option-argument, try to split `-aaaaaa` into individual options\n(-a -a ..) or use `-a=aaaaa` syntax to disambiguate");
 
     let r = parser.run_inner(&["-b"]).unwrap_err().unwrap_stderr();
     // single char typos are too random
@@ -35,7 +35,7 @@ fn short_cmd() {
 
     assert_eq!(
         r,
-        "Expected `COMMAND ...`, got `c`. Pass `--help` for usage information"
+        "expected `COMMAND ...`, got `c`. Pass `--help` for usage information"
     );
 }
 
@@ -54,7 +54,7 @@ fn double_dashes_no_fallback() {
 
     assert_eq!(
         r,
-        "No such flag: `-llvm` (with one dash), did you mean `--llvm`?"
+        "no such flag: `-llvm` (with one dash), did you mean `--llvm`?"
     );
 }
 
@@ -72,7 +72,7 @@ fn double_dashes_fallback() {
 
     assert_eq!(
         r,
-        "No such flag: `-llvm` (with one dash), did you mean `--llvm`?"
+        "no such flag: `-llvm` (with one dash), did you mean `--llvm`?"
     );
 }
 
@@ -96,7 +96,7 @@ fn double_dash_with_optional_positional() {
 
     assert_eq!(
         r,
-        "No such flag: `-llvm` (with one dash), did you mean `--llvm`?"
+        "no such flag: `-llvm` (with one dash), did you mean `--llvm`?"
     );
 }
 
@@ -123,7 +123,7 @@ fn inside_out_command_parser() {
         .unwrap_stderr();
     assert_eq!(
         r,
-        "Flag `--oneline` is not valid in this context, did you mean to pass it to command `log`?"
+        "flag `--oneline` is not valid in this context, did you mean to pass it to command `log`?"
     );
 }
 
@@ -137,7 +137,7 @@ fn flag_specified_twice() {
         .unwrap_stderr();
     assert_eq!(
         r,
-        "Argument `--flag` cannot be used multiple times in this context"
+        "argument `--flag` cannot be used multiple times in this context"
     );
 }
 
@@ -168,7 +168,7 @@ fn ux_discussion() {
         r,
         // everything before ":" comes from bpaf, after ":" - it's an error specific
         // to FromStr instance.
-        "Couldn't parse `tru`: provided string was not `true` or `false`"
+        "couldn't parse `tru`: provided string was not `true` or `false`"
     );
 
     let r = parser
@@ -176,7 +176,7 @@ fn ux_discussion() {
         .unwrap_err()
         .unwrap_stderr();
 
-    assert_eq!(r, "No such flag: `--bool-fla`, did you mean `--bool-flag`?");
+    assert_eq!(r, "no such flag: `--bool-fla`, did you mean `--bool-flag`?");
 
     let r = parser
         .run_inner(&["--bool-flag", "--bool-flag"])
@@ -185,7 +185,7 @@ fn ux_discussion() {
 
     assert_eq!(
         r,
-        "Expected `--setBool`, got `--bool-flag`. Pass `--help` for usage information"
+        "expected `--setBool`, got `--bool-flag`. Pass `--help` for usage information"
     );
 }
 
@@ -194,13 +194,13 @@ fn suggest_typo_fix() {
     let p = long("flag").switch().to_options();
 
     let r = p.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(r, "no such flag: `--fla`, did you mean `--flag`?");
 
     let r = p
         .run_inner(&["--fla", "--fla"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(r, "no such flag: `--fla`, did you mean `--flag`?");
 
     let r = p
         .run_inner(&["--flag", "--flag"])
@@ -208,7 +208,7 @@ fn suggest_typo_fix() {
         .unwrap_stderr();
     assert_eq!(
         r,
-        "Argument `--flag` cannot be used multiple times in this context"
+        "argument `--flag` cannot be used multiple times in this context"
     );
 }
 

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -50,11 +50,11 @@ fn dash_is_positional() {
 #[test]
 fn helpful_error_message() {
     let parser = positional::<String>("FOO")
-        .some("You need to specify at least one FOO")
+        .some("you need to specify at least one FOO")
         .to_options();
 
     let err = parser.run_inner(&[]).unwrap_err().unwrap_stderr();
-    assert_eq!("You need to specify at least one FOO", err);
+    assert_eq!("you need to specify at least one FOO", err);
 }
 
 #[test]
@@ -133,14 +133,14 @@ fn strictly_positional() {
     );
 
     let r = parser.run_inner(&["a"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `A` to be on the right side of `--`");
+    assert_eq!(r, "expected `A` to be on the right side of `--`");
 
     let r = parser.run_inner(&["--", "a"]).unwrap();
     assert_eq!(r, "a");
 
     let r = parser.run_inner(&["a", "--"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `A` to be on the right side of `--`");
+    assert_eq!(r, "expected `A` to be on the right side of `--`");
 
     let r = parser.run_inner(&["--"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `A`, pass `--help` for usage information");
+    assert_eq!(r, "expected `A`, pass `--help` for usage information");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -66,7 +66,7 @@ fn simple_two_optional_flags() {
         .unwrap_err()
         .unwrap_stderr();
     assert_eq!(
-        "Argument `-a` cannot be used multiple times in this context",
+        "argument `-a` cannot be used multiple times in this context",
         err
     );
 
@@ -104,7 +104,7 @@ fn simple_two_optional_flags_with_one_hidden() {
         .unwrap_err()
         .unwrap_stderr();
     assert_eq!(
-        "Argument `-a` cannot be used multiple times in this context",
+        "argument `-a` cannot be used multiple times in this context",
         err
     );
 
@@ -151,7 +151,7 @@ Available options:
     // must specify one of the required flags
     let err = decorated.run_inner(&[]).unwrap_err().unwrap_stderr();
     assert_eq!(
-        "Expected `-a`, `-b`, or more, pass `--help` for usage information",
+        "expected `-a`, `-b`, or more, pass `--help` for usage information",
         err
     );
 }
@@ -184,7 +184,7 @@ Available options:
     // must specify one of the required flags
     let err = decorated.run_inner(&[]).unwrap_err().unwrap_stderr();
     assert_eq!(
-        "Expected `-a`, `-b`, or more, pass `--help` for usage information",
+        "expected `-a`, `-b`, or more, pass `--help` for usage information",
         err
     );
 }
@@ -244,7 +244,7 @@ fn fallback_with_err() {
     assert_eq!(r, 1);
 
     let r = parser.run_inner(&["-a", "x"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Couldn't parse `x`: invalid digit found in string");
+    assert_eq!(r, "couldn't parse `x`: invalid digit found in string");
 
     let r = parser.run_inner(&[]).unwrap_err().unwrap_stderr();
     assert_eq!(r, "nope");
@@ -269,7 +269,7 @@ Available options:
         .run_inner(&["-a", "x12"])
         .unwrap_err()
         .unwrap_stderr();
-    let expected_err = "Couldn't parse `x12`: invalid digit found in string";
+    let expected_err = "couldn't parse `x12`: invalid digit found in string";
     assert_eq!(expected_err, err);
 
     let err = decorated.run_inner(&["-a"]).unwrap_err().unwrap_stderr();
@@ -285,14 +285,14 @@ fn parse_errors() {
         .run_inner(&["-a", "123x"])
         .unwrap_err()
         .unwrap_stderr();
-    let expected_err = "Couldn't parse `123x`: invalid digit found in string";
+    let expected_err = "couldn't parse `123x`: invalid digit found in string";
     assert_eq!(expected_err, err);
 
     let err = decorated
         .run_inner(&["-b", "123x"])
         .unwrap_err()
         .unwrap_stderr();
-    let expected_err = "Expected `-a=ARG`, got `-b`. Pass `--help` for usage information";
+    let expected_err = "expected `-a=ARG`, got `-b`. Pass `--help` for usage information";
     assert_eq!(expected_err, err);
 
     let err = decorated
@@ -566,7 +566,7 @@ mod git {
     fn no_command() {
         let parser = setup();
 
-        let expected_err = "Expected `COMMAND ...`, pass `--help` for usage information";
+        let expected_err = "expected `COMMAND ...`, pass `--help` for usage information";
         assert_eq!(
             expected_err,
             parser.run_inner(&[]).unwrap_err().unwrap_stderr()
@@ -724,7 +724,7 @@ fn simple_cargo_helper() {
         .unwrap_err()
         .unwrap_stderr();
     assert_eq!(
-        "Argument `-a` cannot be used multiple times in this context",
+        "argument `-a` cannot be used multiple times in this context",
         err
     );
 
@@ -775,7 +775,7 @@ Available options:
     assert_eq!(help, expected);
 
     let r = parser.run_inner(&[]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Environment variable `BPAF_SECRET_API_KEY2` is not set");
+    assert_eq!(r, "environment variable `BPAF_SECRET_API_KEY2` is not set");
 }
 
 #[test]
@@ -1006,12 +1006,12 @@ fn command_preserves_custom_failure_message() {
     let inner = fail::<()>(msg).to_options();
 
     let err = inner.run_inner(&[]).unwrap_err().unwrap_stderr();
-    assert_eq!(err, msg);
+    assert_eq!(err, "need more cheese");
 
     let outer = inner.command("feed").to_options();
 
     let err = outer.run_inner(&["feed"]).unwrap_err().unwrap_stderr();
-    assert_eq!(err, msg);
+    assert_eq!(err, "need more cheese");
 }
 
 #[test]
@@ -1025,7 +1025,7 @@ fn optional_error_handling() {
     assert_eq!(res, Some(3));
 
     let res = p.run_inner(&["-p", "pi"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "Couldn't parse `pi`: invalid digit found in string");
+    assert_eq!(res, "couldn't parse `pi`: invalid digit found in string");
 }
 
 #[test]
@@ -1039,7 +1039,7 @@ fn many_error_handling() {
     assert_eq!(res, vec![3]);
 
     let res = p.run_inner(&["-p", "pi"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "Couldn't parse `pi`: invalid digit found in string");
+    assert_eq!(res, "couldn't parse `pi`: invalid digit found in string");
 }
 
 #[test]
@@ -1049,7 +1049,7 @@ fn failure_is_not_stupid_1() {
     let parser = construct!(a, b).to_options();
 
     let res = parser.run_inner(&["-a", "42"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "Couldn't parse: nope");
+    assert_eq!(res, "couldn't parse: nope");
 }
 
 #[test]
@@ -1064,7 +1064,7 @@ fn failure_is_not_stupid_2() {
         .run_inner(&["-a", "42", "-b", "42"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(res, "Couldn't parse: nope");
+    assert_eq!(res, "couldn't parse: nope");
 }
 
 #[test]
@@ -1074,7 +1074,7 @@ fn no_fallback_out_of_command_parser() {
     let parser = construct!([alt1, alt2]).to_options();
 
     let res = parser.run_inner(&["cmd"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "Expected `NAME`, pass `--help` for usage information");
+    assert_eq!(res, "expected `NAME`, pass `--help` for usage information");
 
     let res = parser.run_inner(&["cmd", "a"]).unwrap();
     assert_eq!(res, "a");
@@ -1090,21 +1090,21 @@ fn did_you_mean_switch() {
     let parser = construct!([a, b]).to_options();
 
     let res = parser.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(res, "no such flag: `--fla`, did you mean `--flag`?");
 
     let res = parser.run_inner(&["flag"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         res,
-        "No such command or positional: `flag`, did you mean `--flag`?"
+        "no such command or positional: `flag`, did you mean `--flag`?"
     );
 
     let res = parser.run_inner(&["--pla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "No such flag: `--pla`, did you mean `--plag`?");
+    assert_eq!(res, "no such flag: `--pla`, did you mean `--plag`?");
 
     let res = parser.run_inner(&["--p"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         res,
-        "No such flag: `--p` (with two dashes), did you mean `-p`?"
+        "no such flag: `--p` (with two dashes), did you mean `-p`?"
     );
 }
 
@@ -1112,7 +1112,7 @@ fn did_you_mean_switch() {
 fn did_you_mean_req_flag() {
     let parser = long("flag").req_flag(()).to_options();
     let res = parser.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(res, "no such flag: `--fla`, did you mean `--flag`?");
 }
 
 #[test]
@@ -1120,13 +1120,13 @@ fn did_you_mean_argument() {
     let parser = long("flag").argument::<String>("VAL").to_options();
 
     let res = parser.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(res, "no such flag: `--fla`, did you mean `--flag`?");
 
     let res = parser
         .run_inner(&["--flg=hellop"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(res, "No such flag: `--flg`, did you mean `--flag`?");
+    assert_eq!(res, "no such flag: `--flg`, did you mean `--flag`?");
 }
 
 #[test]
@@ -1140,11 +1140,11 @@ fn did_you_mean_command() {
     let res = parser.run_inner(&["comman"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         res,
-        "No such command or positional: `comman`, did you mean `command`?"
+        "no such command or positional: `comman`, did you mean `command`?"
     );
 
     let res = parser.run_inner(&["--comman"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "No such flag: `--comman`, did you mean `command`?");
+    assert_eq!(res, "no such flag: `--comman`, did you mean `command`?");
 }
 
 #[test]
@@ -1157,22 +1157,22 @@ fn did_you_mean_two_and_arguments() {
         .run_inner(&["--flag", "--parametr"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--parametr`, did you mean `--parameter`?");
+    assert_eq!(r, "no such flag: `--parametr`, did you mean `--parameter`?");
 
     let r = parser
         .run_inner(&["--flag", "--paramet=value"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--paramet`, did you mean `--parameter`?");
+    assert_eq!(r, "no such flag: `--paramet`, did you mean `--parameter`?");
 
     let r = parser
         .run_inner(&["--parameter", "--flg"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--flg`, did you mean `--flag`?");
+    assert_eq!(r, "no such flag: `--flg`, did you mean `--flag`?");
 
     let r = parser.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(r, "no such flag: `--fla`, did you mean `--flag`?");
 }
 
 #[test]
@@ -1182,19 +1182,19 @@ fn did_you_mean_two_or_arguments() {
     let parser = cargo_helper("cmd", construct!([a, b])).to_options();
 
     let r = parser.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(r, "no such flag: `--fla`, did you mean `--flag`?");
 
     let r = parser
         .run_inner(&["--flag", "--parametr"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--parametr`, did you mean `--parameter`?");
+    assert_eq!(r, "no such flag: `--parametr`, did you mean `--parameter`?");
 
     let r = parser
         .run_inner(&["--parametr", "--flag"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--parametr`, did you mean `--parameter`?");
+    assert_eq!(r, "no such flag: `--parametr`, did you mean `--parameter`?");
 
     let r = parser
         .run_inner(&["--parameter", "--flag"])
@@ -1252,10 +1252,10 @@ fn cargo_show_asm_issue_from_str() {
         .run_inner(&["asm", "-t", "x"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(res, "Couldn't parse `x`: invalid digit found in string");
+    assert_eq!(res, "couldn't parse `x`: invalid digit found in string");
 
     let res = parser.run_inner(&["-t", "x"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "Couldn't parse `x`: invalid digit found in string");
+    assert_eq!(res, "couldn't parse `x`: invalid digit found in string");
 }
 
 #[test]
@@ -1272,10 +1272,10 @@ fn cargo_show_asm_issue_parse() {
         .run_inner(&["asm", "-t", "x"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(res, "Couldn't parse `x`: nope");
+    assert_eq!(res, "couldn't parse `x`: nope");
 
     let res = parser.run_inner(&["-t", "x"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "Couldn't parse `x`: nope");
+    assert_eq!(res, "couldn't parse `x`: nope");
 }
 
 // problematic case looks something like this:
@@ -1294,10 +1294,10 @@ fn cargo_show_asm_issue_unknown_switch() {
         .run_inner(&["asm", "--fla"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(res, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(res, "no such flag: `--fla`, did you mean `--flag`?");
 
     let res = parser.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
-    assert_eq!(res, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(res, "no such flag: `--fla`, did you mean `--flag`?");
 }
 
 #[test]
@@ -1309,26 +1309,26 @@ fn did_you_mean_inside_command() {
     let r = parser.run_inner(&["--fla"]).unwrap_err().unwrap_stderr();
     assert_eq!(
         r,
-        "Expected `COMMAND ...`, got `--fla`. Pass `--help` for usage information"
+        "expected `COMMAND ...`, got `--fla`. Pass `--help` for usage information"
     );
 
     let r = parser
         .run_inner(&["cmd", "--fla"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--fla`, did you mean `--flag`?");
+    assert_eq!(r, "no such flag: `--fla`, did you mean `--flag`?");
 
     let r = parser
         .run_inner(&["cmd", "--flag", "--parametr"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--parametr`, did you mean `--parameter`?");
+    assert_eq!(r, "no such flag: `--parametr`, did you mean `--parameter`?");
 
     let r = parser
         .run_inner(&["cmd", "--parametr", "--flag"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "No such flag: `--parametr`, did you mean `--parameter`?");
+    assert_eq!(r, "no such flag: `--parametr`, did you mean `--parameter`?");
 
     let r = parser
         .run_inner(&["cmd", "--parameter", "--flag"])
@@ -1367,7 +1367,7 @@ fn parse_many_errors_positional() {
     assert_eq!(r, vec![1, 2, 3]);
 
     let r = p.run_inner(&["1", "2", "x"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Couldn't parse `x`: invalid digit found in string");
+    assert_eq!(r, "couldn't parse `x`: invalid digit found in string");
 }
 
 #[test]
@@ -1381,7 +1381,7 @@ fn parse_many_errors_flag() {
         .run_inner(&["-p", "1", "-p", "x"])
         .unwrap_err()
         .unwrap_stderr();
-    assert_eq!(r, "Couldn't parse `x`: invalid digit found in string");
+    assert_eq!(r, "couldn't parse `x`: invalid digit found in string");
 }
 
 #[test]
@@ -1393,7 +1393,7 @@ fn command_with_req_parameters() {
         .to_options();
 
     let r = p.run_inner(&["cmd"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `X`, pass `--help` for usage information");
+    assert_eq!(r, "expected `X`, pass `--help` for usage information");
 }
 
 #[test]
@@ -1709,7 +1709,7 @@ fn option_requires_other_option1() {
     let parser = construct!(a, b).optional().to_options();
 
     let r = parser.run_inner(&["-a"]).unwrap_err().unwrap_stderr();
-    assert_eq!(r, "Expected `-b=B`, pass `--help` for usage information");
+    assert_eq!(r, "expected `-b=B`, pass `--help` for usage information");
 }
 
 #[test]


### PR DESCRIPTION
```diff
-"Expected `A`, pass `--help` for usage information"
+"Error: expected `A`, pass `--help` for usage information"
```