### PR TITLE
fix: emit a level 2 heading for sub commands in markdown

### DIFF
--- a/src/buffer/html.rs
+++ b/src/buffer/html.rs
@@ -319,6 +319,7 @@ impl Doc {
         let mut mono = 0;
         let mut def_list = false;
         let mut code_block = false;
+        let mut app_name_seen = false;
         for (ix, token) in self.tokens.iter().copied().enumerate() {
             match token {
                 Token::Text { bytes, style } => {
@@ -384,7 +385,12 @@ impl Doc {
                     match b {
                         Block::Header => {
                             blank_markdown_line(&mut res);
-                            res.push_str("# ");
+                            if app_name_seen {
+                                res.push_str("## ");
+                            } else {
+                                res.push_str("# ");
+                                app_name_seen = true
+                            }
                         }
                         Block::Section2 => {
                             res.push_str("");

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -75,7 +75,7 @@ fn nested() {
   * [`options alpha`↴](#options-alpha)
   * [`options beta`↴](#options-beta)
 
-# options
+## options
 
 Options
 
@@ -91,7 +91,7 @@ Options
 - **`beta`** &mdash; \n  Beta
 
 
-# options alpha
+## options alpha
 
 Alpha
 
@@ -100,7 +100,7 @@ Alpha
 - **`-h`**, **`--help`** &mdash; \n  Prints help information
 
 
-# options beta
+## options beta
 
 Beta
 


### PR DESCRIPTION
Currently, the markdown generated emits `# Header`, level one.

When the markdown is rendered to HTML, it creates `<h1>` tags, which are incorrect from the SEO point of view. Only one `h1` should be present in a page.

PR emits a `h1`  only for the app name and `h2` for the rest.

