### PR TITLE
Release 0.9.5 + 0.5.5 derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.5.3", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.5.5", optional = true }
 owo-colors = { version = "3.5.0", default-features = false, optional = true }
 supports-color = { version = "2.0.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # Change Log
 
-## bpaf [0.9.5] - Unreleased
+## bpaf [0.9.5], bpaf_derive [0.5.5] - 2023-08-24
 - fancier squashing: parse `-abfoo` as `-a -b=foo` if b is a short argument
+- `bpaf_derive`: make sure command aliases are actually working
 
 ## bpaf [0.9.4] - 2023-08-08
 - add `help` to `ParseFlag` and `ParseArgument`

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.5.3"
+version = "0.5.5"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"


### PR DESCRIPTION
- fancier squashing: parse `-abfoo` as `-a -b=foo` if b is a short argument (#267)
- `bpaf_derive`: make sure command aliases are actually working (#278)
