### PR TITLE
Make sure hidden env-only flags, switches and arguments work

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## bpaf [0.9.6], bpaf_derive [0.5.6] - Unreleased
+- make sure env-only arguments and flags are working
+
 ## bpaf [0.9.5], bpaf_derive [0.5.5] - 2023-08-24
 - fancier squashing: parse `-abfoo` as `-a -b=foo` if b is a short argument
 - `bpaf_derive`: make sure command aliases are actually working

--- a/src/complete_gen.rs
+++ b/src/complete_gen.rs
@@ -49,14 +49,16 @@ impl State {
     pub(crate) fn push_flag(&mut self, named: &NamedArg) {
         let depth = self.depth();
         if let Some(comp) = self.comp_mut() {
-            comp.comps.push(Comp::Flag {
-                extra: CompExtra {
-                    depth,
-                    group: None,
-                    help: named.help.as_ref().and_then(Doc::to_completion),
-                },
-                name: ShortLong::from(named),
-            });
+            if let Ok(name) = ShortLong::try_from(named) {
+                comp.comps.push(Comp::Flag {
+                    extra: CompExtra {
+                        depth,
+                        group: None,
+                        help: named.help.as_ref().and_then(Doc::to_completion),
+                    },
+                    name,
+                });
+            }
         }
     }
 
@@ -64,15 +66,17 @@ impl State {
     pub(crate) fn push_argument(&mut self, named: &NamedArg, metavar: &'static str) {
         let depth = self.depth();
         if let Some(comp) = self.comp_mut() {
-            comp.comps.push(Comp::Argument {
-                extra: CompExtra {
-                    depth,
-                    group: None,
-                    help: named.help.as_ref().and_then(Doc::to_completion),
-                },
-                metavar,
-                name: ShortLong::from(named),
-            });
+            if let Ok(name) = ShortLong::try_from(named) {
+                comp.comps.push(Comp::Argument {
+                    extra: CompExtra {
+                        depth,
+                        group: None,
+                        help: named.help.as_ref().and_then(Doc::to_completion),
+                    },
+                    metavar,
+                    name,
+                });
+            }
         }
     }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -116,13 +116,15 @@ impl ShortLong {
     }
 }
 
-impl From<&NamedArg> for ShortLong {
-    fn from(named: &NamedArg) -> Self {
+impl TryFrom<&NamedArg> for ShortLong {
+    type Error = ();
+
+    fn try_from(named: &NamedArg) -> Result<Self, Self::Error> {
         match (named.short.is_empty(), named.long.is_empty()) {
-            (true, true) => unreachable!("Named should have either short or long name"),
-            (true, false) => Self::Long(named.long[0]),
-            (false, true) => Self::Short(named.short[0]),
-            (false, false) => Self::ShortLong(named.short[0], named.long[0]),
+            (true, true) => Err(()),
+            (true, false) => Ok(Self::Long(named.long[0])),
+            (false, true) => Ok(Self::Short(named.short[0])),
+            (false, false) => Ok(Self::ShortLong(named.short[0], named.long[0])),
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1708,6 +1708,30 @@ fn many_env() {
 }
 
 #[test]
+fn env_hidden_arg() {
+    std::env::set_var("USER1", "top s3cr3t");
+    let parser = env("USER1").argument::<String>("USER").to_options();
+    let r = parser.run_inner(&[]).unwrap();
+    assert_eq!(r, "top s3cr3t");
+}
+
+#[test]
+fn env_hidden_switch() {
+    std::env::set_var("USER1", "top s3cr3t");
+    let parser = env("USER1").switch().to_options();
+    let r = parser.run_inner(&[]).unwrap();
+    assert!(r);
+}
+
+#[test]
+fn env_hidden_flag() {
+    std::env::set_var("USER1", "top s3cr3t");
+    let parser = env("USER1").flag(true, false).to_options();
+    let r = parser.run_inner(&[]).unwrap();
+    assert!(r);
+}
+
+#[test]
 fn some_env() {
     std::env::set_var("USER1", "top s3cr3t");
     let parser = short('v')


### PR DESCRIPTION
Removes one of the `unreachable!()` branches that became reachable after I added `env` only parsers. Parse, don't validate yet again...