### PR TITLE
Scan for positional items instead of trying to take the next available

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## bpaf [0.9.6], bpaf_derive [0.5.6] - Unreleased
 - make sure env-only arguments and flags are working
 - support raw identifiers in derive macro (#282)
+- better error messages for unexpected values that prevent positional parses
 
 ## bpaf [0.9.5], bpaf_derive [0.5.5] - 2023-08-24
 - fancier squashing: parse `-abfoo` as `-a -b=foo` if b is a short argument

--- a/src/docs2/adjacent_struct_0.md
+++ b/src/docs2/adjacent_struct_0.md
@@ -139,7 +139,7 @@ Options { point: [Point { point: (), x: 10, y: 20, z: 3.1415 }, Point { point: (
 
 <div class='bpaf-doc'>
 $ app --point 10 20 --rotate 3.1415<br>
-<b>Error:</b> expected <tt><i>Z</i></tt>, got <b>--rotate</b>. Pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> expected <tt><i>Z</i></tt>, pass <tt><b>--help</b></tt> for usage information
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/compose_basic_to_options.md
+++ b/src/docs2/compose_basic_to_options.md
@@ -57,7 +57,7 @@ The other one is `--version` - passing a string literal or something like
 
 <div class='bpaf-doc'>
 $ app --version<br>
-Version: 3.1415
+<p>Version: 3.1415</p>
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/custom_help_version.md
+++ b/src/docs2/custom_help_version.md
@@ -115,7 +115,7 @@ both working
 
 <div class='bpaf-doc'>
 $ app --version<br>
-Version: 0.42
+<p>Version: 0.42</p>
 <style>
 div.bpaf-doc {
     padding: 14px;
@@ -134,7 +134,7 @@ div.bpaf-doc  { padding-left: 1em; }
 
 <div class='bpaf-doc'>
 $ app -v<br>
-Version: 0.42
+<p>Version: 0.42</p>
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/derive_basic_custom_consumer.md
+++ b/src/docs2/derive_basic_custom_consumer.md
@@ -64,7 +64,7 @@ long name is missing
 
 <div class='bpaf-doc'>
 $ app --switch 42<br>
-<b>Error:</b> expected <tt><i>NUM</i></tt>, got <b>--switch</b>. Pass <tt><b>--help</b></tt> for usage information
+<b>Error:</b> <b>--switch</b> is not expected in this context
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/src/docs2/to_options.md
+++ b/src/docs2/to_options.md
@@ -82,7 +82,7 @@ The other one is `--version` - passing a string literal or something like
 
 <div class='bpaf-doc'>
 $ app --version<br>
-Version: 3.1415
+<p>Version: 3.1415</p>
 <style>
 div.bpaf-doc {
     padding: 14px;

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -199,3 +199,35 @@ fn adjacent_option_complains_to() {
     // TODO - this should point to the whole "-ayam" thing
     assert_eq!(r, "couldn't parse `yam`: invalid digit found in string");
 }
+
+#[test]
+fn some_pos_with_invalid_flag() {
+    let a = short('a').switch();
+    let b = positional::<usize>("B").some("Want B");
+    let parser = construct!(a, b).to_options();
+
+    let r = parser.run_inner(&["-c", "12"]).unwrap_err().unwrap_stderr();
+    assert_eq!(r, "`-c` is not expected in this context");
+
+    let r = parser.run_inner(&["12", "-c"]).unwrap_err().unwrap_stderr();
+    assert_eq!(r, "`-c` is not expected in this context");
+}
+
+#[test]
+fn pos_with_invalid_arg() {
+    let a = short('a').argument::<usize>("A").optional();
+    let b = positional::<usize>("B");
+    let parser = construct!(a, b).to_options();
+
+    let r = parser.run_inner(&["-c", "12"]).unwrap_err().unwrap_stderr();
+    assert_eq!(r, "`-c` is not expected in this context");
+
+    let r = parser.run_inner(&["12", "-c"]).unwrap_err().unwrap_stderr();
+    assert_eq!(r, "`-c` is not expected in this context");
+
+    let r = parser.run_inner(&["-c", "t"]).unwrap_err().unwrap_stderr();
+    assert_eq!(r, "couldn't parse `t`: invalid digit found in string");
+
+    let r = parser.run_inner(&["t", "-c"]).unwrap_err().unwrap_stderr();
+    assert_eq!(r, "couldn't parse `t`: invalid digit found in string");
+}


### PR DESCRIPTION
`positional` should be used either after all the named items or as an item adjacent to a named item in some way, still after all the named items within the scope.
    
In case of valid user input scanning for or picking up the front item gives the same results. When user specifies an invalid item - it will not be consumed during normal scanning so picking the front item fails.
    
Error from positional item failing with "not present" will take the priority over "not expected" from invalid item resulting in a bad errormessage.
