### PR TITLE
Fix syntax error in Bash completion

### DIFF
--- a/src/complete_shell.rs
+++ b/src/complete_shell.rs
@@ -163,7 +163,7 @@ pub(crate) fn render_bash(
     let mut res = String::new();
 
     if items.is_empty() && ops.is_empty() {
-        return Ok(format!("COMPREPLY += ( {:?})\n", full_lit));
+        return Ok(format!("COMPREPLY+=( {:?})\n", full_lit));
     }
 
     for op in ops {


### PR DESCRIPTION
The completion settings output by this library contains a syntax error. This was originally reported in https://github.com/akinomyoga/ble.sh/issues/368 for the completion setting for the `chezmoi_modify_manager` command.