### PR TITLE
docs: Include documentation for manpages

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -60,6 +60,8 @@ jobs:
         run: cargo build --all-features -p docs2 &&  git diff && git diff-index --quiet HEAD --
 
       - name: Rustdoc
+        env:
+          RUSTDOCFLAGS: -D warnings
         run: cargo doc --all --no-deps --all-features
 
       - name: formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bpaf = { path = ".",  features = ["derive", "extradocs", "autocomplete", "docgen
 [package.metadata.docs.rs]
 features = ["unstable-docs"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
-rustdoc-args = ["--generate-link-to-definition"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ dull-color = ["color"]
 docgen = []
 
 # this feature is used for local development to make it easier to generate documentation
-unstable-doc = ["derive", "extradocs", "autocomplete", "batteries"]
+unstable-doc = ["derive", "extradocs", "autocomplete", "batteries", "docgen"]
 
 [workspace.metadata.cauwugo]
 bpaf = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bpaf = { path = ".",  features = ["derive", "extradocs", "autocomplete", "docgen
 
 
 [package.metadata.docs.rs]
-features = ["derive", "extradocs", "autocomplete", "batteries"]
+features = ["unstable-docs"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["--generate-link-to-definition"]
 
@@ -44,6 +44,9 @@ color = ["supports-color", "owo-colors"]
 bright-color = ["color"]
 dull-color = ["color"]
 docgen = []
+
+# this feature is used for local development to make it easier to generate documentation
+unstable-doc = ["derive", "extradocs", "autocomplete", "batteries"]
 
 [workspace.metadata.cauwugo]
 bpaf = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::redundant_else)] // not useful
 #![allow(rustdoc::redundant_explicit_links)] // two random markdown parsers I tried only supports explicit links
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Lightweight and flexible command line argument parser with derive and combinatoric style API
 


### PR DESCRIPTION
From [reddit](https://www.reddit.com/r/rust/comments/184ijwg/ripgrep_14_released_hyperlink_support_regex/kaw5kz7/):

>  While I don't use lexopt I have been looking for a way to automatically generate a man page for a while (with bpaf in my case for one project, xflags for another project).

I was confused by this because manpages have been referenced before.  Looking on docs.rs, I just see

![image](https://github.com/pacak/bpaf/assets/60961/67872431-81e3-430d-b419-6a0c76cc0a10)

The link doesn't resolve to anything.

With this set of changes, it will now resolved to

![image](https://github.com/pacak/bpaf/assets/60961/78fbabe7-cead-488d-b318-ae20ec911ae9)

Notes:
- As a contributor, knowing the exact set of features to enable was frustrating, so I copied the pattern from `clap` of having a feature for this.  I prefaced it with `unstable-` to communicate that there are no compatibility guarantees.  There are RFCs for improving this situation.
- I put the nightly feature behind `--cfg=docsrs` so that way people on stable can still reproduce most of the documentation