### PR TITLE
Release 0.9.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -19,7 +19,7 @@ include = [
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.5.6", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.5.7", optional = true }
 owo-colors = { version = "3.5.0", default-features = false, optional = true }
 supports-color = { version = "2.0.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## bpaf [0.9.7], bpaf_derive [0.5.7] - 2023-11-28
+- updated documentation
+- support for `#[bpaf(ignore_rustdoc)]`
+
 ## bpaf [0.9.6], bpaf_derive [0.5.6] - 2023-10-30
 - make sure env-only arguments and flags are working
 - support raw identifiers in derive macro (#282)

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"

--- a/bpaf_derive/src/attrs.rs
+++ b/bpaf_derive/src/attrs.rs
@@ -373,6 +373,8 @@ pub(crate) struct FieldAttrs {
 
     /// help specified by help(xxx)
     pub help: Vec<CustomHelp>,
+
+    pub(crate) ignore_rustdoc: bool,
 }
 
 impl Name {
@@ -564,7 +566,9 @@ impl Parse for FieldAttrs {
         loop {
             let fork = input.fork();
             let kw = input.parse::<Ident>()?;
-            if let Some(name) = Name::parse(input, &kw)? {
+            if kw == "ignore_rustdoc" {
+                res.ignore_rustdoc = true;
+            } else if let Some(name) = Name::parse(input, &kw)? {
                 res.naming.push(name);
             } else if let Some(cons) = Consumer::parse(input, &kw)? {
                 res.consumer.push(cons);

--- a/bpaf_derive/src/field_tests.rs
+++ b/bpaf_derive/src/field_tests.rs
@@ -700,6 +700,19 @@ fn any_field_1() {
 }
 
 #[test]
+fn unnamed_field_with_ignore_rustdoc() {
+    let input: UnnamedField = parse_quote! {
+        #[bpaf(any("FOO", Some), ignore_rustdoc)]
+        /// help
+        String
+    };
+    let output = quote! {
+        ::bpaf::any::<String, _, _>("FOO", Some)
+    };
+    assert_eq!(input.to_token_stream().to_string(), output.to_string());
+}
+
+#[test]
 fn any_field_2() {
     let input: UnnamedField = parse_quote! {
         #[bpaf(any("FOO", Some))]
@@ -798,6 +811,32 @@ fn unit_fields_are_required() {
     };
     let output = quote! {
         ::bpaf::long("name").help("help").req_flag(())
+    };
+    assert_eq!(input.to_token_stream().to_string(), output.to_string());
+}
+
+#[test]
+fn ignore_rustdoc_without_help() {
+    let input: NamedField = parse_quote! {
+        /// help
+        #[bpaf(ignore_rustdoc)]
+        name: ()
+    };
+    let output = quote! {
+        ::bpaf::long("name").req_flag(())
+    };
+    assert_eq!(input.to_token_stream().to_string(), output.to_string());
+}
+
+#[test]
+fn ignore_rustdoc_with_help() {
+    let input: NamedField = parse_quote! {
+        /// help
+        #[bpaf(help("custom help"), ignore_rustdoc)]
+        name: ()
+    };
+    let output = quote! {
+        ::bpaf::long("name").help("custom help").req_flag(())
     };
     assert_eq!(input.to_token_stream().to_string(), output.to_string());
 }

--- a/bpaf_derive/src/help.rs
+++ b/bpaf_derive/src/help.rs
@@ -1,6 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::Expr;
+use syn::{
+    parse::{Parse, ParseStream},
+    Expr, Result,
+};
 
 #[derive(Debug)]
 pub(crate) enum Help {
@@ -20,5 +23,11 @@ impl ToTokens for Help {
 impl From<&str> for Help {
     fn from(value: &str) -> Self {
         Help::Doc(value.to_string())
+    }
+}
+
+impl Parse for Help {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Help::Custom(input.parse()?))
     }
 }

--- a/bpaf_derive/src/named_field.rs
+++ b/bpaf_derive/src/named_field.rs
@@ -168,9 +168,13 @@ impl StructField {
 
     #[allow(clippy::too_many_lines)]
     pub(crate) fn make(name: Option<Ident>, ty: Type, attrs: &[Attribute]) -> Result<Self> {
-        let (field_attrs, help) = parse_bpaf_doc_attrs::<FieldAttrs>(attrs)?;
+        let (field_attrs, mut help) = parse_bpaf_doc_attrs::<FieldAttrs>(attrs)?;
 
         let mut field_attrs = field_attrs.unwrap_or_default();
+
+        if field_attrs.ignore_rustdoc {
+            help = None;
+        }
 
         let derived_consumer = field_attrs.consumer.is_empty();
 
@@ -252,7 +256,7 @@ impl StructField {
         | Consumer::Positional { ty, .. }
         | Consumer::Any { ty, .. } = &mut cons
         {
-            if matches!(ty, None) {
+            if ty.is_none() {
                 match &shape {
                     Shape::Optional(t) | Shape::Multiple(t) | Shape::Direct(t) => {
                         *ty = Some(t.clone());

--- a/bpaf_derive/src/td.rs
+++ b/bpaf_derive/src/td.rs
@@ -55,6 +55,8 @@ pub(crate) struct TopInfo {
     pub(crate) custom_name: Option<Ident>,
     /// add .boxed() at the end
     pub(crate) boxed: bool,
+    /// don't convert rustdoc to group_help, help, etc.
+    pub(crate) ignore_rustdoc: bool,
 
     pub(crate) mode: Mode,
     pub(crate) attrs: Vec<TopAttr>,
@@ -68,6 +70,7 @@ impl Default for TopInfo {
             boxed: false,
             mode: Mode::Parser,
             attrs: Vec::new(),
+            ignore_rustdoc: false,
         }
     }
 }
@@ -136,6 +139,7 @@ impl Parse for TopInfo {
         let mut private = false;
         let mut custom_name = None;
         let mut boxed = false;
+        let mut ignore_rustdoc = false;
         let mode = {
             let first = input.fork().parse::<Ident>()?;
             if first == "options" {
@@ -203,6 +207,8 @@ impl Parse for TopInfo {
                 attrs.push(TopAttr::Usage(parse_arg(input)?));
             } else if let Some(pd) = PostDecor::parse(input, &kw)? {
                 attrs.push(TopAttr::PostDecor(pd));
+            } else if kw == "ignore_rustdoc" {
+                ignore_rustdoc = true;
             } else {
                 return Err(Error::new_spanned(
                     kw,
@@ -220,6 +226,7 @@ impl Parse for TopInfo {
         }
 
         Ok(TopInfo {
+            ignore_rustdoc,
             private,
             custom_name,
             boxed,

--- a/bpaf_derive/src/top.rs
+++ b/bpaf_derive/src/top.rs
@@ -59,8 +59,12 @@ impl Parse for Top {
             boxed,
             mode,
             attrs: td_attrs,
+            ignore_rustdoc,
         } = top_decor.unwrap_or_default();
 
+        if ignore_rustdoc {
+            help = None;
+        }
         let vis = input.parse::<Visibility>()?;
 
         let mut body = Body::parse(input)?;

--- a/bpaf_derive/src/top_tests.rs
+++ b/bpaf_derive/src/top_tests.rs
@@ -1015,6 +1015,63 @@ fn single_unit_adjacent_command() {
 }
 
 #[test]
+fn ingore_doc_comment_top_level_1() {
+    let top: Top = parse_quote! {
+        #[derive(Debug, Clone, Bpaf)]
+        /// present
+        #[bpaf(ignore_rustdoc)]
+        enum Mode {
+            /// intel help
+            Intel,
+            /// att help
+            Att,
+        }
+    };
+
+    let expected = quote! {
+        fn mode() -> impl ::bpaf::Parser<Mode> {
+            #[allow(unused_imports)]
+            use ::bpaf::Parser;
+            {
+                let alt0 = ::bpaf::long("intel").help("intel help").req_flag(Mode::Intel);
+                let alt1 = ::bpaf::long("att").help("att help").req_flag(Mode::Att);
+                ::bpaf::construct!([alt0, alt1, ])
+            }
+        }
+    };
+    assert_eq!(top.to_token_stream().to_string(), expected.to_string());
+}
+
+#[test]
+fn ingore_doc_comment_top_level_2() {
+    let top: Top = parse_quote! {
+        #[derive(Debug, Clone, Bpaf)]
+        #[bpaf(options, ignore_rustdoc)]
+        /// present
+        enum Mode {
+            /// intel help
+            Intel,
+            /// att help
+            Att,
+        }
+    };
+
+    let expected = quote! {
+        fn mode() -> ::bpaf::OptionParser<Mode> {
+            #[allow(unused_imports)]
+            use ::bpaf::Parser;
+            {
+                let alt0 = ::bpaf::long("intel").help("intel help").req_flag(Mode::Intel);
+                let alt1 = ::bpaf::long("att").help("att help").req_flag(Mode::Att);
+                ::bpaf::construct!([alt0, alt1,])
+            }
+            .to_options()
+        }
+    };
+    assert_eq!(top.to_token_stream().to_string(), expected.to_string());
+}
+
+#[test]
 fn top_comment_is_group_help_enum() {
     let top: Top = parse_quote! {
         #[derive(Debug, Clone, Bpaf)]

--- a/bpaf_derive/src/top_tests.rs
+++ b/bpaf_derive/src/top_tests.rs
@@ -89,8 +89,6 @@ fn top_struct_options1() {
                 }
                 .to_options()
                 .descr("those are options")
-                .header("header")
-                .footer("footer")
                 .header(h)
                 .footer(f)
         }
@@ -145,24 +143,45 @@ fn struct_options2() {
 }
 
 #[test]
-fn struct_command() {
+fn struct_command_no_decor() {
     let input: Top = parse_quote! {
         /// those are options
         #[bpaf(command)]
-        struct Opt { foo: bool, }
+        struct Opt;
     };
 
     let expected = quote! {
         fn opt() -> impl ::bpaf::Parser<Opt> {
             #[allow (unused_imports)]
             use ::bpaf::Parser;
-            {
-                let foo = ::bpaf::long("foo").switch();
-                ::bpaf::construct!(Opt {foo, })
-            }
-            .to_options()
+            ::bpaf::pure(Opt)
+                .to_options()
                 .descr("those are options")
                 .command("opt")
+        }
+    };
+    assert_eq!(input.to_token_stream().to_string(), expected.to_string());
+}
+
+#[test]
+fn struct_command_decor() {
+    let input: Top = parse_quote! {
+        /// those are options
+        #[bpaf(command, descr(descr), header(header), footer(footer), help(help))]
+        struct Opt;
+    };
+
+    let expected = quote! {
+        fn opt() -> impl ::bpaf::Parser<Opt> {
+            #[allow (unused_imports)]
+            use ::bpaf::Parser;
+            ::bpaf::pure(Opt)
+                .to_options()
+                .descr(descr)
+                .header(header)
+                .footer(footer)
+                .command("opt")
+                .help(help)
         }
     };
     assert_eq!(input.to_token_stream().to_string(), expected.to_string());
@@ -197,11 +216,41 @@ fn struct_command_short() {
 #[should_panic(expected = "Can't construct a parser from empty enum")]
 #[test]
 fn empty_enum() {
-    let _: Top = parse_quote! {
+    let x: Top = parse_quote! {
         enum Opt { }
     };
+    todo!("{:?}", x);
 }
 */
+
+#[test]
+fn unnamed_command_enum() {
+    let input: Top = parse_quote! {
+        #[bpaf(command)]
+        enum Opts {
+            #[bpaf(command("alpha1"))]
+            Alpha,
+            Beta,
+            Gamma,
+        }
+    };
+
+    let expected = quote! {
+        fn opts() -> impl ::bpaf::Parser<Opts> {
+            #[allow(unused_imports)]
+            use ::bpaf::Parser;
+            {
+                let alt0 = ::bpaf::pure(Opts::Alpha).to_options().command("alpha1");
+                let alt1 = ::bpaf::long("beta").req_flag(Opts::Beta);
+                let alt2 = ::bpaf::long("gamma").req_flag(Opts::Gamma);
+                ::bpaf::construct!([alt0, alt1, alt2,])
+            }
+            .to_options()
+            .command("opts")
+        }
+    };
+    assert_eq!(input.to_token_stream().to_string(), expected.to_string());
+}
 
 #[test]
 fn enum_markdownish() {


### PR DESCRIPTION
- updated documentation a bit
- support for `#[bpaf(ignore_rustdoc)]`
- support for `descr`, `header`, `footer` and `help` top level annotation for `command` and `options`

Now you can tell `bpaf` to ignore rust doc comments

```rust
#[derive(Debug, Clone, Bpaf)]
/// This gets ignored
#[bpaf(options, ignore_rustdoc)]
struct Options {
        #[bpaf(ignore_rustdoc, help("use this help instead")]
        /// help  // <- this gets ignored
        foo: String
}
```


```rust
/// those are options // <- this gets ignored in favor of explicit descr
#[bpaf(command, descr("descr"), header("header"), footer("footer"), help("help"))]
struct Opt;
```