### PR TITLE
error: separate app name and supports with a space

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+
+## bpaf - unreleased
+- fix formatting in ambiguity error message
+
 ## bpaf [0.9.8] - 2023-12-06
 - fix docs.rs build
 - bump deps

--- a/src/error.rs
+++ b/src/error.rs
@@ -407,7 +407,7 @@ impl Message {
 
                 if let Some(name) = args.path.first() {
                     doc.literal(name);
-                    doc.text("supports ");
+                    doc.text(" supports ");
                 } else {
                     doc.text("app supports ");
                 }


### PR DESCRIPTION
Mentioned in https://github.com/pacak/bpaf/issues/325