### PR TITLE
bpaf_derive: allow specification of a custom crate path to resolve proc_macro hygiene related issues that might develop in some situations

### DIFF
--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"
 keywords = ["args", "arguments", "cli", "parser", "parse"]
-authors = [ "Michael Baykov <manpacket@gmail.com>" ]
+authors = ["Michael Baykov <manpacket@gmail.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pacak/bpaf"
@@ -15,7 +15,7 @@ name = "bpaf_derive"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.2", features = ["full", "extra-traits"] }
+syn = { version = "2.0.2", features = ["full", "extra-traits", "visit-mut"] }
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
 

--- a/bpaf_derive/src/attrs.rs
+++ b/bpaf_derive/src/attrs.rs
@@ -36,7 +36,7 @@ impl ToTokens for TurboFish<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Consumer {
     Switch {
         span: Span,
@@ -187,7 +187,7 @@ impl ToTokens for StrictName {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum Post {
     /// Those items can change the type of the result
     Parse(PostParse),
@@ -243,7 +243,7 @@ impl ToTokens for PostDecor {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum PostParse {
     Adjacent { span: Span },
     Catch { span: Span },
@@ -273,7 +273,7 @@ impl PostParse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum PostDecor {
     Complete {
         span: Span,
@@ -528,13 +528,14 @@ impl PostDecor {
         }))
     }
 }
+
 #[derive(Debug)]
 pub(crate) struct CustomHelp {
     pub span: Span,
     pub doc: Box<Expr>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct EnumPrefix(pub Ident);
 
 impl ToTokens for EnumPrefix {

--- a/bpaf_derive/src/custom_path.rs
+++ b/bpaf_derive/src/custom_path.rs
@@ -1,0 +1,205 @@
+use syn::{
+    punctuated::Punctuated,
+    token::{self, PathSep},
+    visit_mut::{self, VisitMut},
+    PathSegment, UseName, UsePath, UseRename, UseTree,
+};
+
+/// Implements [`syn::visit_mut::VisitMut`] to find
+/// those [`Path`](syn::Path)s which match
+/// [`query`](Self::target) and replace them with [`target`](Self::target).
+pub(crate) struct CratePathReplacer {
+    /// The prefix to search for within an input path.
+    query: syn::Path,
+    /// The prefix we wish the input path to have.
+    target: syn::Path,
+}
+
+impl CratePathReplacer {
+    pub(crate) fn new(target: syn::Path, replacement: syn::Path) -> Self {
+        CratePathReplacer {
+            query: target,
+            target: replacement,
+        }
+    }
+
+    /// Check if both [`query`](Self::query) and `input` have the same leading
+    /// path segment (`::`) responsible for marking [a path as
+    /// "global"](https://doc.rust-lang.org/reference/procedural-macros.html#procedural-macro-hygiene).
+    ///
+    /// If these do not match, no replacement will be performed.
+    fn path_global_match(&self, input: &mut syn::Path) -> bool {
+        self.query.leading_colon.is_some() && input.leading_colon.is_some()
+    }
+
+    /// Check if the initial segments of `input` match [`query`](Self::query).
+    ///
+    /// If these do not match, no replacement will be performed.
+    fn path_segments_match(&self, input: &mut syn::Path) -> bool {
+        self.query
+            .segments
+            .iter()
+            .zip(input.segments.iter())
+            .all(|(f, o)| f == o)
+    }
+
+    /// Replaces the prefix of `input` with those of [`target`](Self::target) if
+    /// the `input` path's prefix matches [`query`](Self::query).
+    fn replace_path_if_match(&self, input: &mut syn::Path) {
+        if self.path_global_match(input) && self.path_segments_match(input) {
+            input.leading_colon = self.target.leading_colon;
+            input.segments = self
+                .target
+                .segments
+                .clone()
+                .into_iter()
+                .chain(
+                    input
+                        .segments
+                        .iter()
+                        .skip(self.query.segments.iter().count())
+                        .cloned(),
+                )
+                .collect::<Punctuated<_, _>>();
+        }
+    }
+
+    fn item_use_global_match(&self, input: &syn::ItemUse) -> bool {
+        self.query.leading_colon == input.leading_colon
+    }
+
+    fn item_use_segments_match<'a, Q: Iterator<Item = &'a PathSegment>>(
+        input: &'a UseTree,
+        query_len: usize,
+        mut query_iter: Q,
+        mut matched_parts: Vec<&'a UseTree>,
+    ) -> Option<(Vec<&'a UseTree>, Option<UseTree>)> {
+        if let Some(next_to_match) = query_iter.next() {
+            match input {
+                UseTree::Path(path) => {
+                    if next_to_match.ident == path.ident {
+                        matched_parts.push(input);
+                        return Self::item_use_segments_match(
+                            path.tree.as_ref(),
+                            query_len,
+                            query_iter,
+                            matched_parts,
+                        );
+                    }
+                }
+                UseTree::Name(name) => {
+                    if next_to_match.ident == name.ident {
+                        if query_iter.next().is_some() {
+                            return None;
+                        } else {
+                            matched_parts.push(input);
+                        }
+                    }
+                }
+                UseTree::Rename(rename) => {
+                    if next_to_match.ident == rename.ident {
+                        if query_iter.next().is_some() {
+                            return None;
+                        } else {
+                            matched_parts.push(input);
+                        }
+                    }
+                }
+                UseTree::Glob(_) => {}
+                UseTree::Group(_) => {}
+            }
+        }
+
+        if query_len == matched_parts.len() {
+            Some((matched_parts, Some(input.clone())))
+        } else {
+            None
+        }
+    }
+
+    fn append_suffix_to_target(
+        &self,
+        matched_parts: Vec<&UseTree>,
+        suffix: Option<UseTree>,
+    ) -> UseTree {
+        let last_input_match = matched_parts
+            .last()
+            .expect("If a match exists, then it the matched prefix must be non-empty.");
+        let mut rev_target_ids = self.target.segments.iter().map(|s| s.ident.clone()).rev();
+        let mut result_tree = match last_input_match {
+            UseTree::Path(_) => {
+                if let Some(suffix_tree) = suffix {
+                    UseTree::Path(UsePath {
+                        ident: rev_target_ids.next().expect(
+                            "error while making a `UseTree::Path`: target should not be empty",
+                        ),
+                        colon2_token: PathSep::default(),
+                        tree: Box::new(suffix_tree),
+                    })
+                } else {
+                    unreachable!("If the last part of the matched input was a path, then there must be some suffix left to attach to complete it.")
+                }
+            }
+            UseTree::Name(_) => {
+                assert!(suffix.is_none(), "If the last part of the matched input was a syn::UseTree::Name, then there shouldn't be any suffix left to attach to the prefix.");
+                UseTree::Name(UseName {
+                    ident: rev_target_ids
+                        .next()
+                        .expect("error while making a `UseTree::Name`: target should not be empty"),
+                })
+            }
+            UseTree::Rename(original_rename) => {
+                assert!(suffix.is_none(), "If the last part of the matched input was a syn::UseTree::Rename, then there shouldn't be any suffix left to attach to the prefix.");
+                UseTree::Rename(UseRename {
+                    ident: rev_target_ids.next().expect(
+                        "error while making a `UseTree::Rename`: target should not be empty",
+                    ),
+                    as_token: token::As::default(),
+                    rename: original_rename.rename.clone(),
+                })
+            }
+            UseTree::Glob(_) => unreachable!(
+                "There is no functionality for matching against a syn::UseTree::Group."
+            ),
+            UseTree::Group(_) => unreachable!(
+                "There is no functionality for matching against a syn::UseTree::Group."
+            ),
+        };
+        for id in rev_target_ids {
+            result_tree = UseTree::Path(UsePath {
+                ident: id,
+                colon2_token: PathSep::default(),
+                tree: Box::new(result_tree),
+            })
+        }
+        result_tree
+    }
+
+    /// Replaces the prefix of `input` with those of [`target`](Self::target) if
+    /// the `input` path's prefix matches [`query`](Self::query).
+    fn replace_item_use_if_match(&self, input: &mut syn::ItemUse) {
+        if self.item_use_global_match(input) {
+            if let Some((matched_prefix, suffix)) = Self::item_use_segments_match(
+                &input.tree,
+                self.query.segments.len(),
+                self.query.segments.iter(),
+                vec![],
+            ) {
+                input.leading_colon = self.target.leading_colon;
+                input.tree = self.append_suffix_to_target(matched_prefix, suffix);
+            }
+        }
+    }
+}
+
+impl VisitMut for CratePathReplacer {
+    fn visit_path_mut(&mut self, path: &mut syn::Path) {
+        self.replace_path_if_match(path);
+        visit_mut::visit_path_mut(self, path);
+    }
+
+    fn visit_item_use_mut(&mut self, item_use: &mut syn::ItemUse) {
+        self.replace_item_use_if_match(item_use);
+        visit_mut::visit_item_use_mut(self, item_use);
+    }
+}

--- a/bpaf_derive/src/help.rs
+++ b/bpaf_derive/src/help.rs
@@ -5,7 +5,7 @@ use syn::{
     Expr, Result,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum Help {
     Custom(Box<Expr>),
     Doc(String),

--- a/bpaf_derive/src/lib.rs
+++ b/bpaf_derive/src/lib.rs
@@ -16,6 +16,7 @@ mod top_tests;
 mod help;
 
 mod td;
+mod custom_path;
 
 use top::Top;
 

--- a/bpaf_derive/src/named_field.rs
+++ b/bpaf_derive/src/named_field.rs
@@ -15,7 +15,7 @@ use crate::{
     utils::to_snake_case,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct StructField {
     pub name: Option<Ident>,
     pub env: Vec<StrictName>,

--- a/bpaf_derive/src/utils.rs
+++ b/bpaf_derive/src/utils.rs
@@ -1,7 +1,7 @@
 use syn::{
     parenthesized,
     parse::{Parse, ParseStream},
-    token, Attribute, Expr, LitChar, LitStr, Result,
+    token, Attribute, Expr, LitChar, LitStr, Result, Token,
 };
 
 pub(crate) fn parse_arg<T: Parse>(input: ParseStream) -> Result<T> {
@@ -18,6 +18,11 @@ pub(crate) fn parse_opt_arg<T: Parse>(input: ParseStream) -> Result<Option<T>> {
     } else {
         Ok(None)
     }
+}
+
+pub(crate) fn parse_name_value<T: Parse>(input: ParseStream) -> Result<T> {
+    let _ = input.parse::<Token![=]>();
+    input.parse::<T>()
 }
 
 pub(crate) fn parse_arg2<A: Parse, B: Parse>(input: ParseStream) -> Result<(A, B)> {


### PR DESCRIPTION
Suppose that we have a crate called `indirector`. 

`indirector` publicly re-exports `bpaf`:

```rust
pub use bpaf;
pub use bpaf::Bpaf;
```

Then, we have a crate called `user`, which imports `indirector`, and uses `bpaf` through it:

```rust
use indirector::bpaf::{Parser, Bpaf};
```

This will cause a hygiene related issue, because currently `bpaf_derive` assumes that `bpaf` is available globally (via `::bpaf`) [in line with the official recommendations](https://doc.rust-lang.org/reference/procedural-macros.html#procedural-macro-hygiene).

There was a [discussion](https://users.rust-lang.org/t/how-to-express-crate-path-in-procedural-macros/91274/1) on how to address this sort of issue, which lead me to [experiment](https://github.com/bzm3r/hygiene_mnwe) with the [two solutions](https://users.rust-lang.org/t/how-to-express-crate-path-in-procedural-macros/91274/17) listed there:

* using `extern crate`: this [does not work](https://github.com/bzm3r/hygiene_mnwe/tree/extern-crate) because because it is not relevant to our situation, as it is for fixing the use of `bpaf_derive` *within* `bpaf` 
* [using the `serde` solution](https://serde.rs/container-attrs.html#crate): this [works](https://github.com/bzm3r/hygiene_mnwe/tree/explicit-path)

So I implemented a simple version of it. I tried to keep the changes as small as possible, but was forced to increase how large a change was made due to the realities of how [`use some::path` is handled in `syn`](https://docs.rs/syn/latest/syn/struct.ItemUse.html).

I have included [one simple test](https://github.com/bzm3r/bpaf/blob/cf60ce4b054a67b637e6ccee5edae55e76cba2fd/bpaf_derive/src/top_tests.rs#L1180), and have also tested it out in the use case where I first ran into this issue. 
