### PR TITLE
Stop supporting colored output for legacy rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 [dependencies]
 bpaf_derive = { path = "./bpaf_derive", version = "=0.5.7", optional = true }
 owo-colors = { version = ">=3.5, <5.0", default-features = false, optional = true }
-supports-color = { version = "2.0.0", optional = true }
+supports-color = { version = ">=2.0.0, <4.0", optional = true }
 
 [dev-dependencies]
 bpaf = { path = ".",  features = ["derive", "extradocs", "autocomplete", "docgen", "batteries", "dull-color"] }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## bpaf [0.9.10] - unreleased
+- due to dependency change colored output for legacy version is no longer supported
 
 ## bpaf [0.9.9] - 2024-01-17
 - fix formatting in ambiguity error message

--- a/legacy/Cargo.toml
+++ b/legacy/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bpaf = { path = "../", features = ["derive", "autocomplete", "dull-color", "docgen"] }
+bpaf = { path = "../", features = ["derive", "autocomplete", "docgen"] }
 bpaf_derive = { path = "../bpaf_derive" }
-rustix = "=0.37.19"
-linux-raw-sys = "=0.3.8"
-is-terminal = "=0.4.7"
 
 [workspace]


### PR DESCRIPTION
This drops the dependency for is-terminal in favor of implementation that comes in stdlib