### PR TITLE
Release 0.9.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -19,7 +19,7 @@ include = [
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.5.7", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.5.10", optional = true }
 owo-colors = { version = ">=3.5, <5.0", default-features = false, optional = true }
 supports-color = { version = ">=2.0.0, <4.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,19 @@
 # Change Log
 
-## bpaf [0.9.10] - unreleased
+
+
+## bpaf [0.9.10], bpaf_derive [0.5.10] - 2024-03-19
 - due to dependency change colored output for legacy version is no longer supported
 - Added `OptionParser::max_width` and `#[bpaf(max_width(xxx))]` to specify maximum
   width of help output
 - Added a custom path attribute to allow using of reexported bpaf
+  thanks @bzm3r
+- support anywhere in bpaf_derive
+  thanks @vallentin
+- small documentation improvements
+  thanks @Boshen
+- minor shell completion improvements
+- avoid panic in case of hidden but required parser argument (#345)
 
 ## bpaf [0.9.9] - 2024-01-17
 - fix formatting in ambiguity error message

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.5.7"
+version = "0.5.10"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"

--- a/src/args.rs
+++ b/src/args.rs
@@ -33,7 +33,7 @@ use crate::{
 /// assert!(value);
 /// ```
 pub struct Args<'a> {
-    items: Box<dyn Iterator<Item = OsString> + 'a>,
+    items: Box<dyn ExactSizeIterator<Item = OsString> + 'a>,
     name: Option<String>,
     #[cfg(feature = "autocomplete")]
     c_rev: Option<usize>,

--- a/src/complete_gen.rs
+++ b/src/complete_gen.rs
@@ -404,8 +404,15 @@ impl State {
             8 => render_bash(&items, &shell, full_lit),
             9 => render_fish(&items, &shell, full_lit, self.path[0].as_str()),
             unk => {
-                eprintln!("Unsupported output revision {}, you need to genenerate your shell completion files for the app", unk);
-                std::process::exit(1);
+                #[cfg(debug_assertions)]
+                {
+                    eprintln!("Unsupported output revision {}, you need to genenerate your shell completion files for the app", unk);
+                    std::process::exit(1);
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    std::process::exit(0);
+                }
             }
         }.unwrap())
     }

--- a/src/complete_run.rs
+++ b/src/complete_run.rs
@@ -5,7 +5,11 @@ fn dump_bash_completer(name: &str) {
     println!(
         r#"_bpaf_dynamic_completion()
 {{
-    source <( "$1" --bpaf-complete-rev=8 "${{COMP_WORDS[@]:1}}" )
+    line="$1 --bpaf-complete-rev=8 ${{COMP_WORDS[@]:1}}"
+    if [[ ${{COMP_WORDS[-1]}} == "" ]]; then
+        line="${{line}} \"\""
+    fi
+    source <( eval ${{line}})
 }}
 complete -o nosort -F _bpaf_dynamic_completion {name}"#,
         name = name,
@@ -15,7 +19,12 @@ complete -o nosort -F _bpaf_dynamic_completion {name}"#,
 fn dump_zsh_completer(name: &str) {
     println!(
         r#"#compdef {name}
-source <( "${{words[1]}}" --bpaf-complete-rev=7 "${{words[@]:1}}" )
+local line
+line="${{words[1]}} --bpaf-complete-rev=7 ${{words[@]:1}}"
+if [[ ${{words[-1]}} == "" ]]; then
+    line="${{line}} \"\""
+fi
+source <(eval ${{line}})
 "#,
         name = name
     );

--- a/src/docs2/choice.md
+++ b/src/docs2/choice.md
@@ -70,7 +70,7 @@ Options { desert: Some("apple") }
 </div>
 
 
-Only one value is consumed at once
+Since parser consumes only one value you can't specify multiple flags of the same type
 
 
 <div class='bpaf-doc'>

--- a/src/error.rs
+++ b/src/error.rs
@@ -597,10 +597,14 @@ impl Message {
 /// go over all the missing items, pick the left most scope
 pub(crate) fn summarize_missing(items: &[MissingItem], inner: &Meta, args: &State) -> Message {
     // missing items can belong to different scopes, pick the best scope to work with
-    let best_item = items
+    let best_item = match items
         .iter()
         .max_by_key(|item| (item.position, item.scope.start))
-        .unwrap();
+    {
+        Some(x) => x,
+        None => return Message::ParseSome("parser requires an extra flag, argument or parameter, but its name is hidden by the author"),
+    };
+
     let mut best_scope = best_item.scope.clone();
 
     let mut saw_command = false;

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -251,3 +251,14 @@ fn hidden_required_field_is_valid_but_strange() {
 
     assert_eq!(r, "parser requires an extra flag, argument or parameter, but its name is hidden by the author");
 }
+
+#[test]
+fn guard_on_fallback() {
+    let parser = short('a')
+        .argument::<usize>("A")
+        .fallback(10)
+        .guard(|a| *a < 10, "too big")
+        .to_options();
+    let r = parser.run_inner(&[]).unwrap_err().unwrap_stderr();
+    assert_eq!(r, "check failed: too big");
+}

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -242,3 +242,12 @@ fn strictly_positional_help() {
         .unwrap_stderr();
     assert_eq!(r, "`--help` is not expected in this context");
 }
+
+#[test]
+fn hidden_required_field_is_valid_but_strange() {
+    let parser = short('a').req_flag(()).hide().to_options();
+
+    let r = parser.run_inner(&[]).unwrap_err().unwrap_stderr();
+
+    assert_eq!(r, "parser requires an extra flag, argument or parameter, but its name is hidden by the author");
+}


### PR DESCRIPTION
- Added `OptionParser::max_width` and `#[bpaf(max_width(xxx))]` to specify maximum
  width of help output
- Added a custom path attribute to allow using of reexported bpaf
  thanks @bzm3r
- support anywhere in bpaf_derive
  thanks @vallentin
- small documentation improvements
  thanks @Boshen
- minor shell completion improvements
- avoid panic in case of hidden but required parser argument (#345)