### PR TITLE
Release 0.9.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.11"
+version = "0.9.12"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+
+## bpaf [0.9.12] - 2024-04-29
+- better error messages
+
 ## bpaf [0.9.11] - 2024-03-24
 - better error messages
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -273,10 +273,10 @@ impl Message {
             Message::Unconsumed(ix) => {
                 if let Some(conflict) = check_conflicts(args) {
                     self = conflict;
-                } else if let Some((ix, suggestion)) = crate::meta_youmean::suggest(args, meta) {
-                    self = Message::Suggestion(ix, suggestion);
                 } else if let Some(prev_ix) = only_once(args, ix) {
                     self = Message::OnlyOnce(prev_ix, ix);
+                } else if let Some((ix, suggestion)) = crate::meta_youmean::suggest(args, meta) {
+                    self = Message::Suggestion(ix, suggestion);
                 }
             }
             Message::Missing(xs) => {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -271,3 +271,29 @@ fn two_required_fields_first_missing() {
     let r = parser.run_inner(&["--b", "1"]).unwrap_err().unwrap_stderr();
     assert_eq!(r, "expected `--a=A`, pass `--help` for usage information");
 }
+
+#[test]
+fn used_only_once_is_more_important_error() {
+    let format = long("format").switch();
+    let sort = long("sort").switch();
+    let filter = long("filter").switch();
+    let opts = construct!(format, sort, filter,).to_options();
+
+    let err = opts
+        .run_inner(&["--filter", "--filter"])
+        .unwrap_err()
+        .unwrap_stderr();
+    assert_eq!(
+        err,
+        "argument `--filter` cannot be used multiple times in this context"
+    );
+
+    let err = opts
+        .run_inner(&["--sort", "--sort"])
+        .unwrap_err()
+        .unwrap_stderr();
+    assert_eq!(
+        err,
+        "argument `--sort` cannot be used multiple times in this context"
+    );
+}


### PR DESCRIPTION
Improve error messages for a scenario where a flag that can be used just once is used twice or more and the whole parser contains a similarly looking flag