### PR TITLE
fix(complete shell): remove quotes for zsh/bash raw, remove duplicated quotes in bash file and dir 

### DIFF
--- a/src/complete_shell.rs
+++ b/src/complete_shell.rs
@@ -129,7 +129,7 @@ pub(crate) fn render_zsh(
             ShellComp::File { mask: Some(mask) } => writeln!(res, "_files -g {}", Shell(mask)),
             ShellComp::Dir { mask: None } => writeln!(res, "_files -/"),
             ShellComp::Dir { mask: Some(mask) } => writeln!(res, "_files -/ -g {}", Shell(mask)),
-            ShellComp::Raw { zsh, .. } => writeln!(res, "{}", Shell(zsh)),
+            ShellComp::Raw { zsh, .. } => writeln!(res, "{}", zsh),
             ShellComp::Nothing => Ok(()),
         }?;
     }
@@ -194,13 +194,13 @@ pub(crate) fn render_bash(
         match op {
             ShellComp::File { mask: None } => write!(res, "_filedir"),
             ShellComp::File { mask: Some(mask) } => {
-                writeln!(res, "_filedir '{}'", Shell(bashmask(mask)))
+                writeln!(res, "_filedir {}", Shell(bashmask(mask)))
             }
             ShellComp::Dir { mask: None } => write!(res, "_filedir -d"),
             ShellComp::Dir { mask: Some(mask) } => {
-                writeln!(res, "_filedir -d '{}'", Shell(bashmask(mask)))
+                writeln!(res, "_filedir -d {}", Shell(bashmask(mask)))
             }
-            ShellComp::Raw { bash, .. } => writeln!(res, "{}", Shell(bash)),
+            ShellComp::Raw { bash, .. } => writeln!(res, "{}", bash),
             ShellComp::Nothing => Ok(()),
         }?;
     }


### PR DESCRIPTION
## Summary

When debugging issue #371 , I noticed the `Raw` shell completion mode was pretty much unusable due to adding extra quotes around the input, causing zsh and bash to interpret the entire raw input as a single command, which would always fail due to not found. Currently it is only possible to use a single command with no args in raw mode. I also noticed an extra set of quotes are being added to file and dirs for bash, already handled by the `Shell` wrapper, which could be causing issues.

## What's changed

- Removed quotes around bash and zsh raw completions, allowing freedom to use arguments/multiple commands in the raw completions
- Removed duplicate quotes around bash file and dir completions, seems like the `Shell` wrapper already handles this and they weren't updated