### PR TITLE
feat: `ParsePositional::not_strict`

### DIFF
--- a/bpaf_derive/src/attrs.rs
+++ b/bpaf_derive/src/attrs.rs
@@ -217,6 +217,7 @@ impl ToTokens for PostParse {
             PostParse::Optional { .. } => quote!(optional()),
             PostParse::Parse { f, .. } => quote!(parse(#f)),
             PostParse::Strict { .. } => quote!(strict()),
+            PostParse::NotStrict { .. } => quote!(not_strict()),
             PostParse::Anywhere { .. } => quote!(anywhere()),
         }
         .to_tokens(tokens);
@@ -256,6 +257,7 @@ pub(crate) enum PostParse {
     Optional { span: Span },
     Parse { span: Span, f: Box<Expr> },
     Strict { span: Span },
+    NotStrict { span: Span },
     Anywhere { span: Span },
 }
 impl PostParse {
@@ -271,6 +273,7 @@ impl PostParse {
             | Self::Optional { span }
             | Self::Parse { span, .. }
             | Self::Strict { span }
+            | Self::NotStrict { span }
             | Self::Anywhere { span } => *span,
         }
     }
@@ -480,6 +483,8 @@ impl PostParse {
             Self::Parse { span, f }
         } else if kw == "strict" {
             Self::Strict { span }
+        } else if kw == "not_strict" {
+            Self::NotStrict { span }
         } else if kw == "some" {
             let msg = parse_arg(input)?;
             Self::Some_ { span, msg }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,9 +42,13 @@ pub(crate) enum Message {
     // those cannot be caught-------------------------------------------------------------
     /// Parsing failed and this is the final output
     ParseFailure(ParseFailure),
+
     /// Tried to consume a strict positional argument, value was present but was not strictly
     /// positional
     StrictPos(usize, Metavar),
+
+    /// Tried to consume a non-strict positional argument, but the value was strict
+    NotStrictPos(usize, Metavar),
 
     /// Parser provided by user failed to parse a value
     ParseFailed(Option<usize>, String),
@@ -87,7 +91,8 @@ impl Message {
             | Message::ParseSome(_)
             | Message::ParseFail(_)
             | Message::Missing(_)
-            | Message::PureFailed(_) => true,
+            | Message::PureFailed(_)
+            | Message::NotStrictPos(_, _) => true,
             Message::StrictPos(_, _)
             | Message::ParseFailed(_, _)
             | Message::GuardFailed(_, _)
@@ -320,6 +325,18 @@ impl Message {
                 doc.metavar(metavar);
                 doc.token(Token::BlockEnd(Block::TermRef));
                 doc.text(" to be on the right side of ");
+                doc.token(Token::BlockStart(Block::TermRef));
+                doc.literal("--");
+                doc.token(Token::BlockEnd(Block::TermRef));
+            }
+
+            // Error: FOO expected to be on the left side of --
+            Message::NotStrictPos(_ix, metavar) => {
+                doc.text("expected ");
+                doc.token(Token::BlockStart(Block::TermRef));
+                doc.metavar(metavar);
+                doc.token(Token::BlockEnd(Block::TermRef));
+                doc.text(" to be on the left side of ");
                 doc.token(Token::BlockStart(Block::TermRef));
                 doc.literal("--");
                 doc.token(Token::BlockEnd(Block::TermRef));


### PR DESCRIPTION
Attempt to resolve #373 by adding `ParsePositional::not_strict`, the inverse of `ParsePositional::strict`. Derive support also added.

Adds new catchable error `NotStrictPos`, and a field `not_strict`, to set the
condition.

Went light on the documentation, since it's just the inverse of the existing and well documented method. Probably missing some test cases and such as well, but tested manually against lutgen, and is a working as expected.