### PR TITLE
Support more masks with multiple extensionss in ShellComp::File

### DIFF
--- a/examples/filenames.rs
+++ b/examples/filenames.rs
@@ -1,0 +1,18 @@
+//! This example shows how to use shell completion to ask for
+//! a file with one of two extensions. If you want to specify just one
+//! extension having it as something like "*.rs" is good enough
+
+use bpaf::{positional, Parser, ShellComp};
+use std::path::PathBuf;
+
+fn main() {
+    let parser = positional::<PathBuf>("FILE")
+        .complete_shell(ShellComp::File {
+            mask: Some("*.(md|toml)"),
+        })
+        .many()
+        .to_options();
+
+    let r = parser.run();
+    println!("{:?}", r);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1146,6 +1146,8 @@ pub trait Parser<T> {
     ///     output: String,
     /// }
     /// ```
+    ///
+    /// For multiple file types correct mask syntax is `"*.(toml|md)"`.
     #[cfg(feature = "autocomplete")]
     fn complete_shell(
         self,


### PR DESCRIPTION
Support masks with multiple extensions via `"*.(md|toml)"`

`zsh` accepts `"*.(md|toml)"`, but bash wants to see `"@(md|toml)"`. To support both we pick saner mask variant (from `zsh`) and in case of `bash` - correct it.


Fixes #371