### PR TITLE
Completion: move careful handling of mix of positional and non-positional items

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -55,6 +55,11 @@ impl Args<'_> {
     ///     .unwrap_stdout();
     /// assert_eq!(r, "-f");
     /// ```
+    ///
+    /// Note to self: shell passes "" as a parameter in situations like foo `--bar TAB`, bpaf
+    /// completion stubs adopt this conventions add pass it along. This is needed so completer can
+    /// tell the difference between `--bar` being completed or an argument to it in the example
+    /// above.
     #[cfg(feature = "autocomplete")]
     #[must_use]
     pub fn set_comp(mut self, rev: usize) -> Self {

--- a/src/complete_shell.rs
+++ b/src/complete_shell.rs
@@ -97,8 +97,8 @@ where
         let depth = args.depth();
         if let Some(comp) = args.comp_mut() {
             for ci in comp_items {
-                if ci.is_metavar().is_some() {
-                    comp.push_shell(self.op, depth);
+                if let Some(is_argument) = ci.is_metavar() {
+                    comp.push_shell(self.op, is_argument, depth);
                 } else {
                     comp.push_comp(ci);
                 }

--- a/tests/chezmoi.rs
+++ b/tests/chezmoi.rs
@@ -1,0 +1,231 @@
+use bpaf::*;
+use std::{path::PathBuf, str::FromStr};
+
+#[derive(Copy, Clone, Debug)]
+pub enum Style {
+    /// Program is in PATH
+    InPath,
+    /// Program is in .utils of chezmoi source state
+    InSrc,
+}
+
+impl FromStr for Style {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "path" => Ok(Style::InPath),
+            "src" => Ok(Style::InSrc),
+            _ => Err("Not valid"),
+        }
+    }
+}
+
+/// Parser for `--style`
+fn style() -> impl Parser<Style> {
+    const DEFAULT: Style = Style::InPath;
+
+    fn complete_fn(input: &String) -> Vec<(&'static str, Option<&'static str>)> {
+        [("path", Some("Is path")), ("src", Some("Is src"))]
+            .into_iter()
+            .filter(|(name, _)| name.starts_with(input))
+            .collect()
+    }
+
+    short('t')
+        .long("style")
+        .help("help message for style")
+        .argument::<String>("STYLE")
+        .complete(complete_fn)
+        .parse(|x| x.parse())
+        .fallback(DEFAULT)
+}
+
+#[derive(Debug, Bpaf)]
+#[bpaf(options, version)]
+pub enum Options {
+    /// Process a single file (containing settings).
+    Process(#[bpaf(positional("FILE"), complete_shell(ShellComp::File{mask: None}))] PathBuf),
+    Add {
+        /// Add a file
+        #[bpaf(short('a'), long("add"))]
+        _a: (),
+        #[bpaf(external)]
+        style: Style,
+        #[bpaf(positional("FILE"), complete_shell(ShellComp::File{mask: None}))]
+        files: Vec<PathBuf>,
+    },
+    Smart {
+        /// Smartly add a file
+        #[bpaf(short('s'), long("smart-add"))]
+        _a: (),
+        #[bpaf(external)]
+        style: Style,
+        #[bpaf(positional("FILE"), complete_shell(ShellComp::File{mask: None}))]
+        files: Vec<PathBuf>,
+    },
+    Doctor {
+        /// Perform environment sanity check
+        #[bpaf(long("doctor"))]
+        _a: (),
+    },
+    Update {
+        /// Perform self update
+        #[bpaf(short('u'), long("upgrade"))]
+        _a: (),
+        /// Do not ask for confirmation before applying updates
+        #[bpaf(long("no-confirm"))]
+        no_confirm: bool,
+    },
+}
+
+#[test]
+fn completion_test_1() {
+    let parser = options();
+
+    let r = parser
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+
+    let expected = "\
+--add\t--add\t\tAdd a file
+--style\t--style=STYLE\t\thelp message for style
+--smart-add\t--smart-add\t\tSmartly add a file
+--style\t--style=STYLE\t\thelp message for style
+--doctor\t--doctor\t\tPerform environment sanity check
+--upgrade\t--upgrade\t\tPerform self update
+--no-confirm\t--no-confirm\t\tDo not ask for confirmation before applying updates
+
+File { mask: None }
+File { mask: None }
+File { mask: None }
+";
+    assert_eq!(r, expected);
+
+    let r = parser
+        .run_inner(Args::from(&["--"]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r, expected);
+
+    let r = parser
+        .run_inner(Args::from(&["--s"]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+
+    // style is valid in two different branches, as far as bpaf is concerned they might be
+    // different. Hopefully shell can deduplicate it?
+    let expected = "\
+--style\t--style=STYLE\t\thelp message for style
+--smart-add\t--smart-add\t\tSmartly add a file
+--style\t--style=STYLE\t\thelp message for style
+
+";
+    assert_eq!(r, expected);
+
+    let r = parser
+        .run_inner(Args::from(&["--smart-add", ""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    let expected = "\
+--style\t--style=STYLE\t\thelp message for style
+
+File { mask: None }
+";
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn completion_test_2() {
+    #[derive(Debug, Bpaf, Clone)]
+    #[bpaf(options, version)]
+    pub enum Options {
+        /// Process a single file (containing settings).
+        Process(#[bpaf(positional("FILE"), complete_shell(ShellComp::File{mask: None}))] PathBuf),
+
+        /// Perform environment sanity check
+        #[bpaf(long("doctor"))]
+        Doctor,
+    }
+
+    let parser = options();
+
+    let r = parser
+        .run_inner(Args::from(&["-"]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+
+    let expected = "\
+--doctor\t--doctor\t\tPerform environment sanity check
+
+File { mask: None }
+";
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn completion_test_3() {
+    #[derive(Debug, Bpaf, Clone)]
+    #[bpaf(options, version)]
+    pub enum Options {
+        /// Process a single file (containing settings).
+        Process(#[bpaf(positional("FILE"), complete_shell(ShellComp::File{mask: None}))] PathBuf),
+
+        /// Perform environment sanity check
+        #[bpaf(long("doctor"))]
+        Doctor,
+
+        /// Print docs
+        #[bpaf(long("document"))]
+        Doc,
+    }
+
+    let parser = options();
+
+    let r = parser
+        .run_inner(Args::from(&["--"]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+
+    let expected = "\
+--doctor\t--doctor\t\tPerform environment sanity check
+--document\t--document\t\tPrint docs
+
+File { mask: None }
+";
+    assert_eq!(r, expected);
+}
+
+#[test]
+fn completion_test_4() {
+    #[derive(Debug, Bpaf, Clone)]
+    #[bpaf(options, version)]
+    pub enum Options {
+        /// Process a single file (containing settings).
+        Process(#[bpaf(positional("FILE"), complete_shell(ShellComp::File{mask: None}))] PathBuf),
+
+        /// Perform environment sanity check
+        #[bpaf(long("doctor"))]
+        Doctor,
+
+        /// Print docs
+        #[bpaf(long("document"))]
+        Doc,
+    }
+
+    let parser = options();
+
+    let r = parser
+        .run_inner(Args::from(&["--d"]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+
+    let expected = "\
+--doctor\t--doctor\t\tPerform environment sanity check
+--document\t--document\t\tPrint docs
+
+";
+
+    assert_eq!(r, expected);
+}

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -2,6 +2,91 @@
 use bpaf::*;
 
 #[test]
+fn mixing_shell_and_positional_1() {
+    let a = || {
+        positional::<String>("DISTANCE")
+            .complete_shell(ShellComp::File { mask: None })
+            .guard(|s| !s.is_empty(), "unreachable")
+            .parse(|s| s.parse::<usize>())
+    };
+    let b = || short('b').help("Option b").req_flag(10);
+
+    let r1 = construct!([b(), a()])
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r1, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
+
+    let r2 = construct!([a(), b()])
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r2, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
+}
+
+#[test]
+fn mixing_shell_and_positional_2() {
+    let a = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
+    let b = || short('b').help("Option b").argument::<usize>("HELLO");
+
+    let r1 = construct!([b(), a()])
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r1, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
+
+    let r2 = construct!([a(), b()])
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r2, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
+}
+
+#[test]
+fn mixing_shell_and_positional_3() {
+    let a = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
+    let b = || short('b').help("Option b").req_flag(10);
+
+    let r1 = construct!(b(), a())
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r1, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
+
+    let r2 = construct!(a(), b())
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r2, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
+}
+
+#[test]
+fn mixing_shell_and_positional_4() {
+    let a = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
+    let b = || short('b').help("Option b").argument::<usize>("HELLO");
+
+    let r1 = construct!(b(), a())
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r1, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
+
+    let r2 = construct!(a(), b())
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r2, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
+}
+
+#[test]
 fn static_complete_test_1() {
     let a = short('a').long("avocado").help("Use avocado").switch();
     let b = short('b').long("banana").help("Use banana").switch();

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -2,88 +2,60 @@
 use bpaf::*;
 
 #[test]
-fn mixing_shell_and_positional_1() {
-    let a = || {
+fn mixing_shell_and_positional_1_flag_or_pos() {
+    let arg = || short('b').help("Option b").req_flag(10);
+    let pos = || {
         positional::<String>("DISTANCE")
             .complete_shell(ShellComp::File { mask: None })
             .guard(|s| !s.is_empty(), "unreachable")
             .parse(|s| s.parse::<usize>())
     };
-    let b = || short('b').help("Option b").req_flag(10);
 
-    let r1 = construct!([b(), a()])
+    let r = construct!([arg(), pos()])
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
+}
+
+#[test]
+fn mixing_shell_and_positional_2_arg_or_pos() {
+    let arg = || short('b').help("Option b").argument::<usize>("HELLO");
+    let pos = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
+
+    let r = construct!([arg(), pos()])
+        .to_options()
+        .run_inner(Args::from(&[""]).set_comp(0))
+        .unwrap_err()
+        .unwrap_stdout();
+    assert_eq!(r, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
+}
+
+#[test]
+fn mixing_shell_and_positional_3_flag_and_pos() {
+    let arg = || short('b').help("Option b").req_flag(10);
+    let pos = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
+
+    let r1 = construct!(arg(), pos())
         .to_options()
         .run_inner(Args::from(&[""]).set_comp(0))
         .unwrap_err()
         .unwrap_stdout();
     assert_eq!(r1, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
-
-    let r2 = construct!([a(), b()])
-        .to_options()
-        .run_inner(Args::from(&[""]).set_comp(0))
-        .unwrap_err()
-        .unwrap_stdout();
-    assert_eq!(r2, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
 }
 
 #[test]
-fn mixing_shell_and_positional_2() {
-    let a = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
-    let b = || short('b').help("Option b").argument::<usize>("HELLO");
+fn mixing_shell_and_positional_4_arg_and_pos() {
+    let arg = || short('b').help("Option b").argument::<usize>("HELLO");
+    let pos = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
 
-    let r1 = construct!([b(), a()])
+    let r = construct!(arg(), pos())
         .to_options()
         .run_inner(Args::from(&[""]).set_comp(0))
         .unwrap_err()
         .unwrap_stdout();
-    assert_eq!(r1, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
-
-    let r2 = construct!([a(), b()])
-        .to_options()
-        .run_inner(Args::from(&[""]).set_comp(0))
-        .unwrap_err()
-        .unwrap_stdout();
-    assert_eq!(r2, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
-}
-
-#[test]
-fn mixing_shell_and_positional_3() {
-    let a = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
-    let b = || short('b').help("Option b").req_flag(10);
-
-    let r1 = construct!(b(), a())
-        .to_options()
-        .run_inner(Args::from(&[""]).set_comp(0))
-        .unwrap_err()
-        .unwrap_stdout();
-    assert_eq!(r1, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
-
-    let r2 = construct!(a(), b())
-        .to_options()
-        .run_inner(Args::from(&[""]).set_comp(0))
-        .unwrap_err()
-        .unwrap_stdout();
-    assert_eq!(r2, "-b\t-b\t\tOption b\n\nFile { mask: None }\n");
-}
-
-#[test]
-fn mixing_shell_and_positional_4() {
-    let a = || positional::<usize>("DISTANCE").complete_shell(ShellComp::File { mask: None });
-    let b = || short('b').help("Option b").argument::<usize>("HELLO");
-
-    let r1 = construct!(b(), a())
-        .to_options()
-        .run_inner(Args::from(&[""]).set_comp(0))
-        .unwrap_err()
-        .unwrap_stdout();
-    assert_eq!(r1, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
-
-    let r2 = construct!(a(), b())
-        .to_options()
-        .run_inner(Args::from(&[""]).set_comp(0))
-        .unwrap_err()
-        .unwrap_stdout();
-    assert_eq!(r2, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
+    assert_eq!(r, "-b\t-b=HELLO\t\tOption b\n\nFile { mask: None }\n");
 }
 
 #[test]


### PR DESCRIPTION
Extracted from #337

- track shell completions origin - named or positional and use similar to other completions
- when combining completions from two branches - use both or use one that captured earlier value