### PR TITLE
Release 0.9.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -19,7 +19,7 @@ include = [
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.5.10", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.5.13", optional = true }
 owo-colors = { version = ">=3.5, <5.0", default-features = false, optional = true }
 supports-color = { version = ">=2.0.0, <4.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,13 @@
 # Change Log
 
-## bpaf [0.9.13] - Unreleased
-- You can now use `fallback_to_usage` in derive macro for options and subcommands
+## bpaf [0.9.13], bpaf_derive [0.5.13] - 2024-09-06
+- You can now use `fallback_to_usage` in derive macro for options and subcommands (#376)
 - Bugfixes related to shell completion and file masks
   thanks @ozwaldorf
 - `not_strict` restriction for positional items (TODO - check the docs)
   thanks @ozwaldorf
+- more shell completion bugfixes (#384, #382, #381)
+- `ParseFailure::print_mesage` (with one `s` is deprecated in favor of the right spelling
 
 
 ## bpaf [0.9.12] - 2024-04-29
@@ -26,6 +28,9 @@
   thanks @Boshen
 - minor shell completion improvements
 - avoid panic in case of hidden but required parser argument (#345)
+- somewhat breaking - `ParseFailure::exit_code` is separated into
+  `ParseFailure::exit_code` and `ParseFailure::print_message`, one produces
+  exit code, one prints the message
 
 ## bpaf [0.9.9] - 2024-01-17
 - fix formatting in ambiguity error message

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.5.10"
+version = "0.5.13"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"

--- a/src/error.rs
+++ b/src/error.rs
@@ -215,8 +215,14 @@ impl ParseFailure {
         }
     }
 
-    /// Prints a message to `stdout` or `stderr` appropriate to the failure.
+    #[doc(hidden)]
+    #[deprecated = "Please use ParseFailure::print_message, with two s"]
     pub fn print_mesage(&self, max_width: usize) {
+        self.print_message(max_width)
+    }
+
+    /// Prints a message to `stdout` or `stderr` appropriate to the failure.
+    pub fn print_message(&self, max_width: usize) {
         let color = Color::default();
         match self {
             ParseFailure::Stdout(msg, full) => {

--- a/src/info.rs
+++ b/src/info.rs
@@ -90,7 +90,7 @@ impl<T> OptionParser<T> {
         match self.run_inner(Args::current_args()) {
             Ok(t) => t,
             Err(err) => {
-                err.print_mesage(self.info.max_width);
+                err.print_message(self.info.max_width);
                 std::process::exit(err.exit_code())
             }
         }


### PR DESCRIPTION
- You can now use `fallback_to_usage` in derive macro for options and subcommands (#376)
- Bugfixes related to shell completion and file masks
  thanks @ozwaldorf
- `not_strict` restriction for positional items (TODO - check the docs)
  thanks @ozwaldorf
- more shell completion bugfixes (#384, #382, #381)
- `ParseFailure::print_mesage` (with one `s` is deprecated in favor of the right spelling
