### PR TITLE
Release 0.9.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -21,7 +21,7 @@ include = [
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.5.16", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.5.17", optional = true }
 owo-colors = { version = ">=3.5, <5.0", default-features = false, optional = true }
 supports-color = { version = ">=2.0.0, <4.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## bpaf [0.9.17], bpaf_derive [0.5.17] - 2025-03-01
+- A new method `format_fallback` allows to format fallback values using
+  a custom formatting function. This extends functionality offered by `format_debug` and
+  `format_display` that use `Debug` and `Display` instances respectively
+  thanks @antalsz
+
 ## bpaf [0.9.16], 2025-01-24
 - treat `pure` as an implicit consumer - don't add unnecessary `.optional()` or `.many()`
 - unbrainfart one of the examples

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.5.16"
+version = "0.5.17"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"


### PR DESCRIPTION
- A new method `format_fallback` allows to format fallback values using
  a custom formatting function. This extends functionality offered by `format_debug` and
  `format_display` that use `Debug` and `Display` instances respectively
  thanks @antalsz