### PR TITLE
Fix description of switch in tutorial

### DIFF
--- a/docs2/src/switch/cases.md
+++ b/docs2/src/switch/cases.md
@@ -2,7 +2,7 @@ In `--help` output `bpaf` shows switches as usual flags with no meta variable at
 
 > --help
 
-Both `switch` and `flag` succeed if value is not present, `switch` returns true, `flag` returns
+Both `switch` and `flag` succeed if value is not present, `switch` returns `false`, `flag` returns
 second value.
 
 >


### PR DESCRIPTION
I am reading the code correctly, `switch` will return false if an optional parameter is missing.