### PR TITLE
Make fallback_to_usage behavior more expected

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -240,7 +240,9 @@ impl<T> OptionParser<T> {
         //
         // outer parser gets value in ParseFailure format
 
-        if self.info.help_if_no_args && args.is_empty() {
+        let res = self.inner.eval(args);
+
+        if res.is_err() && self.info.help_if_no_args && args.is_empty() {
             let buffer = render_help(
                 &args.path,
                 &self.info,
@@ -251,7 +253,6 @@ impl<T> OptionParser<T> {
             return Err(ParseFailure::Stdout(buffer, false));
         };
 
-        let res = self.inner.eval(args);
         if let Err(Error(Message::ParseFailure(failure))) = res {
             return Err(failure);
         }


### PR DESCRIPTION
fallback_to_usage should apply if parser fails to produce a result.