### PR TITLE
Release 0.9.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.18"
+version = "0.9.19"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## bpaf [0.9.19] - 2025-03-13
+- Fix one more problematic corner case of `fallback_to_usage` - it should no override
+  inner parser printing usage or version info
+
 ## bpaf [0.9.18] - 2025-03-06
 - Several small documentation fixes (#414, #413)
   thanks @yerke

--- a/src/info.rs
+++ b/src/info.rs
@@ -240,9 +240,16 @@ impl<T> OptionParser<T> {
         //
         // outer parser gets value in ParseFailure format
 
+        let no_args = args.is_empty();
         let res = self.inner.eval(args);
 
-        if res.is_err() && self.info.help_if_no_args && args.is_empty() {
+        // Don't override inner parser printing usage info
+        let parser_failed = match res {
+            Ok(_) | Err(Error(Message::ParseFailure(ParseFailure::Stdout(..)))) => false,
+            Err(_) => true,
+        };
+
+        if parser_failed && self.info.help_if_no_args && no_args {
             let buffer = render_help(
                 &args.path,
                 &self.info,

--- a/tests/help_format.rs
+++ b/tests/help_format.rs
@@ -656,3 +656,26 @@ fn help_and_version_newline() {
         .unwrap_stdout();
     assert_eq!(r, "Version: 1\n");
 }
+
+#[test]
+fn fallback_to_usage_and_commands() {
+    let parser = pure(())
+        .to_options()
+        .descr("inner")
+        .command("cmd")
+        .to_options()
+        .descr("outer")
+        .fallback_to_usage();
+
+    let r = parser
+        .run_inner(&["cmd", "--help"])
+        .unwrap_err()
+        .unwrap_stdout();
+    let expected =
+        "inner\n\nUsage: cmd \n\nAvailable options:\n    -h, --help  Prints help information\n";
+    assert_eq!(r, expected);
+
+    let r = parser.run_inner(&[]).unwrap_err().unwrap_stdout();
+    let expected = "outer\n\nUsage: COMMAND ...\n\nAvailable options:\n    -h, --help  Prints help information\n\nAvailable commands:\n    cmd         inner\n";
+    assert_eq!(r, expected);
+}


### PR DESCRIPTION
Fix one more problematic corner case of `fallback_to_usage`. It should not override inner parser printing usage or version info:

If parser supports subcommand "foo" then passing "app foo --help" should return help for "foo", not for the app itself