### PR TITLE
Fix order/label of examples in custom_usage.md

### DIFF
--- a/docs2/Cargo.toml
+++ b/docs2/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 bpaf = { path = "../", features = ["autocomplete", "derive"] }
 pretty_assertions = "1.3"
-comptester = { path = "../comptester/" }
+comptester = { path = "../comptester/", optional = true }
 
 [build-dependencies]
 shell-words = "1.1.0"

--- a/docs2/src/custom_usage/combine.rs
+++ b/docs2/src/custom_usage/combine.rs
@@ -1,19 +1,28 @@
 //
 use bpaf::{doc::*, *};
-const BINARY_USAGE: &[(&str, Style)] = &[
-    ("--binary", Style::Literal),
-    ("=", Style::Text),
-    ("BINARY", Style::Metavar),
-];
-
-#[derive(Debug, Clone, Bpaf)]
-#[bpaf(options)]
+#[derive(Debug, Clone)]
 pub struct Options {
-    /// Binary to run
-    #[bpaf(short, long, argument("BIN"), custom_usage(BINARY_USAGE))]
     binary: Option<String>,
-
-    /// Package to check
-    #[bpaf(short, long, argument("PACKAGE"))]
     package: Option<String>,
+}
+
+pub fn options() -> OptionParser<Options> {
+    let binary = short('b')
+        .long("binary")
+        .help("Binary to run")
+        .argument("BIN")
+        .optional()
+        .custom_usage(&[
+            ("--binary", Style::Literal),
+            ("=", Style::Text),
+            ("BINARY", Style::Metavar),
+        ]);
+
+    let package = short('p')
+        .long("package")
+        .help("Package to check")
+        .argument("PACKAGE")
+        .optional();
+
+    construct!(Options { binary, package }).to_options()
 }

--- a/docs2/src/custom_usage/derive.rs
+++ b/docs2/src/custom_usage/derive.rs
@@ -1,28 +1,19 @@
 //
 use bpaf::{doc::*, *};
-#[derive(Debug, Clone)]
+const BINARY_USAGE: &[(&str, Style)] = &[
+    ("--binary", Style::Literal),
+    ("=", Style::Text),
+    ("BINARY", Style::Metavar),
+];
+
+#[derive(Debug, Clone, Bpaf)]
+#[bpaf(options)]
 pub struct Options {
+    /// Binary to run
+    #[bpaf(short, long, argument("BIN"), custom_usage(BINARY_USAGE))]
     binary: Option<String>,
+
+    /// Package to check
+    #[bpaf(short, long, argument("PACKAGE"))]
     package: Option<String>,
-}
-
-pub fn options() -> OptionParser<Options> {
-    let binary = short('b')
-        .long("binary")
-        .help("Binary to run")
-        .argument("BIN")
-        .optional()
-        .custom_usage(&[
-            ("--binary", Style::Literal),
-            ("=", Style::Text),
-            ("BINARY", Style::Metavar),
-        ]);
-
-    let package = short('p')
-        .long("package")
-        .help("Package to check")
-        .argument("PACKAGE")
-        .optional();
-
-    construct!(Options { binary, package }).to_options()
 }

--- a/docs2/src/lib.rs
+++ b/docs2/src/lib.rs
@@ -3,7 +3,6 @@
 
 use bpaf::{Args, OptionParser, ParseFailure};
 
-use comptester::zsh_comptest_with;
 #[cfg(test)]
 use pretty_assertions::assert_eq;
 
@@ -58,16 +57,12 @@ fn import_escaped_source(
     }
 }
 
-fn run_and_render<T: std::fmt::Debug>(
-    res: &mut String,
-    options: OptionParser<T>,
-    args: &[&str],
-    all_args: &str,
-    complete: Option<&str>,
-) -> std::fmt::Result {
+#[cfg(feature = "comptester")]
+fn run_and_render_completion(res: &mut String, all_args: &str, complete: &str) -> std::fmt::Result {
+    use comptester::zsh_comptest_with;
     use std::fmt::Write;
 
-    if let Some("zsh") = complete {
+    if "zsh" == complete {
         let all_args = all_args.strip_suffix("\\t").unwrap();
         let comp = zsh_comptest_with(&(all_args.to_owned() + "\t"), 80).unwrap();
         writeln!(
@@ -81,6 +76,17 @@ fn run_and_render<T: std::fmt::Debug>(
         )?;
         return Ok(());
     }
+
+    Ok(())
+}
+
+fn run_and_render<T: std::fmt::Debug>(
+    res: &mut String,
+    options: OptionParser<T>,
+    args: &[&str],
+    all_args: &str,
+) -> std::fmt::Result {
+    use std::fmt::Write;
 
     match options.run_inner(Args::from(args).set_name("app")) {
         Ok(ok) => writeln!(

--- a/src/docs2/custom_usage.md
+++ b/src/docs2/custom_usage.md
@@ -1,33 +1,6 @@
 <details><summary>Combinatoric example</summary>
 
 ```no_run
-const BINARY_USAGE: &[(&str, Style)] = &[
-    ("--binary", Style::Literal),
-    ("=", Style::Text),
-    ("BINARY", Style::Metavar),
-];
-
-#[derive(Debug, Clone, Bpaf)]
-#[bpaf(options)]
-pub struct Options {
-    /// Binary to run
-    #[bpaf(short, long, argument("BIN"), custom_usage(BINARY_USAGE))]
-    binary: Option<String>,
-
-    /// Package to check
-    #[bpaf(short, long, argument("PACKAGE"))]
-    package: Option<String>,
-}
-
-fn main() {
-    println!("{:?}", options().run())
-}
-```
-
-</details>
-<details><summary>Derive example</summary>
-
-```no_run
 #[derive(Debug, Clone)]
 pub struct Options {
     binary: Option<String>,
@@ -53,6 +26,33 @@ pub fn options() -> OptionParser<Options> {
         .optional();
 
     construct!(Options { binary, package }).to_options()
+}
+
+fn main() {
+    println!("{:?}", options().run())
+}
+```
+
+</details>
+<details><summary>Derive example</summary>
+
+```no_run
+const BINARY_USAGE: &[(&str, Style)] = &[
+    ("--binary", Style::Literal),
+    ("=", Style::Text),
+    ("BINARY", Style::Metavar),
+];
+
+#[derive(Debug, Clone, Bpaf)]
+#[bpaf(options)]
+pub struct Options {
+    /// Binary to run
+    #[bpaf(short, long, argument("BIN"), custom_usage(BINARY_USAGE))]
+    binary: Option<String>,
+
+    /// Package to check
+    #[bpaf(short, long, argument("PACKAGE"))]
+    package: Option<String>,
 }
 
 fn main() {


### PR DESCRIPTION
The Derive example was under the "Combinatoric" section and vice-versa.