### PR TITLE
Bump MSRV and tests to 1.68

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -68,7 +68,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   compat:
-    name: Tests on linux with 1.56 toolchain
+    name: Tests on linux with 1.68 toolchain
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -77,7 +77,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.56
+          toolchain: 1.68
 
       - name: test minimal features
         run: cargo run --manifest-path legacy/Cargo.toml -- --help

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [ "Michael Baykov <manpacket@gmail.com>" ]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pacak/bpaf"
-rust-version = "1.56"
+rust-version = "1.68"
 include = [
   "src/**/*",
   "Cargo.toml",


### PR DESCRIPTION
1.56 was some arbitrary version I cared to support at a time, might as well bump it to 1.68