### PR TITLE
Suppress enum_variant_names

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -4,6 +4,7 @@ use std::ffi::{OsStr, OsString};
 ///
 /// [`OsString`] in Short/Long correspond to orignal command line item used for errors
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum Arg {
     /// short flag: `-f`
     ///

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -264,7 +264,7 @@ pub enum Style {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::enum_variant_names)]
 pub(crate) enum Block {
     /// level 1 section header, block for separate command inside manpage, not used in --help
     Header,


### PR DESCRIPTION
I would not change the enum names just for this.