### PR TITLE
Fix a remaining warning

### DIFF
--- a/src/complete_gen.rs
+++ b/src/complete_gen.rs
@@ -201,7 +201,7 @@ impl Complete {
         self.comps.extend(comps);
     }
 
-    pub(crate) fn drain_comps(&mut self) -> std::vec::Drain<Comp> {
+    pub(crate) fn drain_comps(&mut self) -> std::vec::Drain<'_, Comp> {
         self.comps.drain(0..)
     }
 
@@ -510,7 +510,7 @@ impl Complete {
         pos_only: bool,
         is_named: bool,
         prefix: Prefix,
-    ) -> (Vec<ShowComp>, Vec<ShellComp>) {
+    ) -> (Vec<ShowComp<'_>>, Vec<ShellComp>) {
         let mut items: Vec<ShowComp> = Vec::new();
         let mut shell = Vec::new();
         let max_depth = self.comps.iter().map(Comp::depth).max().unwrap_or(0);

--- a/src/complete_shell.rs
+++ b/src/complete_shell.rs
@@ -190,7 +190,7 @@ pub(crate) fn render_bash(
     // handling this would be ignoring the shell machinery and handling masks on the
     // Rust side... But for now try this
     //
-    fn bashmask(i: &str) -> Cow<str> {
+    fn bashmask(i: &str) -> Cow<'_, str> {
         let i = i.strip_prefix("*.").unwrap_or(i);
 
         if i.starts_with('(') {


### PR DESCRIPTION
```
warning: hiding a lifetime that's elided elsewhere is confusing
```