### PR TITLE
bpaf_derive: allow arbitrary expression in `external`

### DIFF
--- a/bpaf_derive/src/attrs.rs
+++ b/bpaf_derive/src/attrs.rs
@@ -2,14 +2,14 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
-    token, Attribute, Error, Expr, Ident, LitChar, LitStr, Path, Result, Type,
+    token, Attribute, Error, Expr, Ident, LitChar, LitStr, Result, Type,
 };
 
 use crate::{
     help::Help,
     utils::{
         doc_comment, parse_arg, parse_arg2, parse_expr, parse_lit_char, parse_lit_str,
-        parse_opt_metavar, to_kebab_case,
+        parse_opt_arg, parse_opt_metavar, to_kebab_case,
     },
 };
 
@@ -67,7 +67,7 @@ pub enum Consumer {
         span: Span,
     },
     External {
-        ident: Option<Path>,
+        expr: Option<Expr>,
         span: Span,
     },
     Pure {
@@ -448,12 +448,8 @@ impl Consumer {
             let present = parse_arg(input)?;
             Consumer::ReqFlag { present, span }
         } else if kw == "external" {
-            let ident = if input.peek(token::Paren) {
-                Some(parse_arg(input)?)
-            } else {
-                None
-            };
-            Consumer::External { ident, span }
+            let expr = parse_opt_arg(input)?;
+            Consumer::External { expr, span }
         } else if kw == "pure" {
             let expr = parse_arg(input)?;
             Consumer::Pure { expr, span }

--- a/bpaf_derive/src/field_tests.rs
+++ b/bpaf_derive/src/field_tests.rs
@@ -171,6 +171,18 @@ fn derive_external_with_path() {
 }
 
 #[test]
+fn derive_external_with_expr() {
+    let input: NamedField = parse_quote! {
+        #[bpaf(external(some_function_call(true, "foo")))]
+        number: f64
+    };
+    let output = quote! {
+        some_function_call(true, "foo")
+    };
+    assert_eq!(input.to_token_stream().to_string(), output.to_string());
+}
+
+#[test]
 fn derive_external_nohelp() {
     let input: NamedField = parse_quote! {
         /// help

--- a/bpaf_derive/src/named_field.rs
+++ b/bpaf_derive/src/named_field.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
-    parse::ParseStream, parse_quote, spanned::Spanned, token, Attribute, Error, Ident, LitStr,
-    Result, Type, Visibility,
+    parse::ParseStream, parse_quote, spanned::Spanned, token, Attribute, Error, Expr, ExprPath,
+    Ident, LitStr, Path, Result, Type, Visibility,
 };
 
 use crate::{
@@ -93,9 +93,15 @@ impl ToTokens for Consumer {
                 let tf = ty.as_ref().map(TurboFish);
                 quote!(::bpaf::positional #tf(#metavar))
             }
-            Consumer::External { ident, .. } => {
-                quote!(#ident())
-            }
+            Consumer::External { expr, .. } => match expr {
+                // plain paths are interpreted as functions to call (for backcompat)
+                Some(Expr::Path(expr)) => {
+                    let fn_ref = &expr.path;
+                    quote!(#fn_ref())
+                }
+                // anything else is interpolated directly
+                something_else => quote!(#something_else),
+            },
             Consumer::Pure { expr, .. } => {
                 quote!(::bpaf::pure(#expr))
             }
@@ -183,15 +189,17 @@ impl StructField {
             None => derive_consumer(name.is_some() || !field_attrs.naming.is_empty(), &ty)?,
         };
 
-        if let Consumer::External { span, ident: None } = &cons {
+        if let Consumer::External { span, expr: None } = &cons {
             let span = *span;
             match name.as_ref() {
                 Some(n) => {
-                    let ident = Ident::new(&to_snake_case(&n.to_string()), n.span());
-                    cons = Consumer::External {
-                        span,
-                        ident: Some(ident.into()),
-                    };
+                    let ident: Path = Ident::new(&to_snake_case(&n.to_string()), n.span()).into();
+                    let expr = Some(Expr::Path(ExprPath {
+                        path: ident,
+                        attrs: vec![],
+                        qself: None,
+                    }));
+                    cons = Consumer::External { span, expr };
                 }
                 None => {
                     return Err(Error::new(


### PR DESCRIPTION
Resolves #270

Does this seem like the right approach? I'm learning Rust, found myself also wanting the feature from #270, so decided to see if I could implement it myself. 🙂

Let me know what you think!