### PR TITLE
Release 0.9.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf"
-version = "0.9.25"
+version = "0.9.26"
 edition = "2021"
 categories = ["command-line-interface"]
 description = "A simple Command Line Argument Parser with parser combinators"
@@ -21,7 +21,7 @@ include = [
 
 
 [dependencies]
-bpaf_derive = { path = "./bpaf_derive", version = "=0.5.23", optional = true }
+bpaf_derive = { path = "./bpaf_derive", version = "=0.5.26", optional = true }
 owo-colors = { version = ">=3.5, <5.0", default-features = false, optional = true }
 supports-color = { version = ">=2.0.0, <4.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## bpaf [0.9.26], bpaf_derive [0.5.26] - 2026-05-13
+- Support struct level doc comments along with `adjacent` (#453)
+
 ## bpaf [0.9.25] - 2026-04-15
 - Change rendering of an adjacent block in Markdown - this is no longer a `###`
   but a regular line item instead. Header messes up with generated navigation on

--- a/bpaf_derive/Cargo.toml
+++ b/bpaf_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpaf_derive"
-version = "0.5.23"
+version = "0.5.26"
 edition = "2018"
 categories = ["command-line-interface"]
 description = "Derive macros for bpaf Command Line Argument Parser"

--- a/bpaf_derive/src/top.rs
+++ b/bpaf_derive/src/top.rs
@@ -306,8 +306,8 @@ impl ToTokens for Top {
                         #[allow(unused_imports)]
                         use ::bpaf::Parser;
                         #body
-                        #group_help
                         #adjacent
+                        #group_help
                         #(.#attrs)*
                         #boxed
                     }

--- a/bpaf_derive/src/top_tests.rs
+++ b/bpaf_derive/src/top_tests.rs
@@ -1113,6 +1113,35 @@ fn adjacent_for_struct() {
 }
 
 #[test]
+fn adjacent_with_group_help() {
+    let top: Top = parse_quote! {
+        #[bpaf(adjacent)]
+        /// help text
+        struct Opts {
+            a: String,
+            b: String,
+        }
+    };
+
+    let expected = quote! {
+        #[doc(hidden)]
+        fn opts() -> impl ::bpaf::Parser<Opts> {
+            #[allow(unused_imports)]
+            use ::bpaf::Parser;
+            {
+                let a = ::bpaf::short('a').argument::<String>("ARG");
+                let b = ::bpaf::short('b').argument::<String>("ARG");
+                ::bpaf::construct!(Opts { a, b, })
+            }
+            .adjacent()
+            .group_help("help text")
+        }
+    };
+
+    assert_eq!(top.to_token_stream().to_string(), expected.to_string());
+}
+
+#[test]
 fn box_for_struct() {
     let top: Top = parse_quote! {
         #[bpaf(boxed)]


### PR DESCRIPTION
Support struct level doc comments along with `adjacent`. (Fixes #453)