### PR TITLE
feat: expose meta variables for custom renderers

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -56,5 +56,15 @@ pub use crate::buffer::{Doc, MetaInfo, Style};
 #[cfg(feature = "docgen")]
 pub use crate::buffer::Section;
 
+// The parser description itself, for rendering documentation in a format bpaf doesn't produce.
+// Start from OptionParser::meta and OptionParser::info, then walk down the tree.
+#[doc(inline)]
+pub use crate::{
+    info::Info,
+    item::{Item, ShortLong},
+    meta::Meta,
+    meta_help::Metavar,
+};
+
 #[cfg(doc)]
 use crate::*;

--- a/src/info.rs
+++ b/src/info.rs
@@ -10,9 +10,11 @@ use crate::{
 
 /// Information about the parser
 ///
-/// No longer public, users are only interacting with it via [`OptionParser`]
+/// Everything an [`OptionParser`] carries on top of the parser itself: the prose that surrounds a
+/// help message and the settings that shape it. Set it with the builder methods on
+/// [`OptionParser`], read it back with [`OptionParser::info`] or from
+/// [`Item::Command`](crate::doc::Item::Command) when documenting a subcommand.
 #[derive(Debug, Clone)]
-#[doc(hidden)]
 pub struct Info {
     /// version field, see [`version`][Info::version]
     pub version: Option<Doc>,
@@ -24,9 +26,13 @@ pub struct Info {
     pub footer: Option<Doc>,
     /// Custom usage field, see [`usage`][Info::usage]
     pub usage: Option<Doc>,
+    /// Parser for the help flag, see [`help_parser`][OptionParser::help_parser]
     pub help_arg: NamedArg,
+    /// Parser for the version flag, see [`version_parser`][OptionParser::version_parser]
     pub version_arg: NamedArg,
+    /// Print the help message when invoked with no arguments at all
     pub help_if_no_args: bool,
+    /// Width the help message is wrapped at, see [`max_width`][OptionParser::max_width]
     pub max_width: usize,
 }
 
@@ -708,6 +714,46 @@ impl<T> OptionParser<T> {
     pub fn max_width(mut self, width: usize) -> Self {
         self.info.max_width = width;
         self
+    }
+
+    /// Shape of the inner parser
+    ///
+    /// The same tree `--help` and the [documentation generators](crate::doc) are rendered from.
+    /// Walk it together with [`info`](OptionParser::info) to render the documentation of a whole
+    /// application in a format `bpaf` doesn't produce itself.
+    ///
+    /// # Usage
+    /// ```rust
+    /// # use bpaf::{*, doc::*};
+    /// fn long_names(meta: &Meta, names: &mut Vec<&'static str>) {
+    ///     match meta {
+    ///         Meta::Item(item) => {
+    ///             if let Item::Flag { name: ShortLong::Long(l) | ShortLong::Both(_, l), .. } = **item {
+    ///                 names.push(l);
+    ///             }
+    ///         }
+    ///         Meta::And(xs) | Meta::Or(xs) => for x in xs { long_names(x, names) },
+    ///         Meta::Optional(x) | Meta::Required(x) | Meta::Adjacent(x) | Meta::Many(x)
+    ///         | Meta::Subsection(x, _) | Meta::Suffix(x, _) | Meta::CustomUsage(x, _)
+    ///         | Meta::Strict(x) => long_names(x, names),
+    ///         Meta::Skip => {}
+    ///     }
+    /// }
+    ///
+    /// let options = short('v').long("verbose").switch().to_options();
+    /// let mut names = Vec::new();
+    /// long_names(&options.meta(), &mut names);
+    /// assert_eq!(names, ["verbose"]);
+    /// ```
+    #[must_use]
+    pub fn meta(&self) -> Meta {
+        self.inner.meta()
+    }
+
+    /// Description, header, footer and version attached to this parser
+    #[must_use]
+    pub fn info(&self) -> &Info {
+        &self.info
     }
 }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -17,7 +17,7 @@ pub enum Item {
         help: Option<Doc>,
     },
     /// Positional item, consumed from the the front of the arguments
-    /// <FILE>
+    /// `<FILE>`
     Positional {
         /// Placeholder name for the value, `FILE` in `<FILE>`
         metavar: Metavar,
@@ -51,8 +51,8 @@ pub enum Item {
         help: Option<Doc>,
     },
     /// Short or long name followed by a value, consumed anywhere
-    /// -f <VAL>
-    /// --file <VAL>
+    /// `-f <VAL>`
+    /// `--file <VAL>`
     Argument {
         /// Names this argument answers to
         name: ShortLong,

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,43 +1,68 @@
 use crate::{info::Info, meta_help::Metavar, parsers::NamedArg, Doc, Meta};
 
-#[doc(hidden)]
+/// A single thing a parser consumes from the command line
+///
+/// Leaves of the [`Meta`] tree. Everything a renderer needs to describe one flag, argument,
+/// positional or command is here: the names it answers to, the metavariable to show for its
+/// value, the environment variable it falls back to and the help text attached to it.
 #[derive(Clone, Debug)]
 pub enum Item {
+    /// Free form item created with [`any`](crate::any)
     Any {
+        /// Rendered in place of a name, since `any` has none
         metavar: Doc,
         /// used by any, moves it from positionals into arguments
         anywhere: bool,
+        /// Help message attached with [`help`](crate::parsers::ParseAny::help)
         help: Option<Doc>,
     },
     /// Positional item, consumed from the the front of the arguments
     /// <FILE>
-    Positional { metavar: Metavar, help: Option<Doc> },
-    Command {
-        name: &'static str,
-        short: Option<char>,
+    Positional {
+        /// Placeholder name for the value, `FILE` in `<FILE>`
+        metavar: Metavar,
+        /// Help message attached with [`help`](crate::parsers::ParsePositional::help)
         help: Option<Doc>,
+    },
+    /// Subcommand with a parser of its own
+    Command {
+        /// Name the subcommand is invoked by
+        name: &'static str,
+        /// Single character alias, if any
+        short: Option<char>,
+        /// Single line summary shown in the parent's help message
+        help: Option<Doc>,
+        /// Shape of the subcommand's own parser, walk it to document nested commands
         meta: Box<Meta>,
+        /// Description, header and footer of the subcommand's help message
         info: Box<Info>,
     },
     /// short or long name, consumed anywhere
     /// -f
     /// --file
     Flag {
+        /// Names this flag answers to
         name: ShortLong,
         /// used for disambiguation
         shorts: Vec<char>,
+        /// Environment variable consulted when the flag is absent
         env: Option<&'static str>,
+        /// Help message attached with [`help`](crate::parsers::NamedArg::help)
         help: Option<Doc>,
     },
     /// Short or long name followed by a value, consumed anywhere
     /// -f <VAL>
     /// --file <VAL>
     Argument {
+        /// Names this argument answers to
         name: ShortLong,
         /// used for disambiguation
         shorts: Vec<char>,
+        /// Placeholder name for the value, `VAL` in `--file <VAL>`
         metavar: Metavar,
+        /// Environment variable consulted when the argument is absent
         env: Option<&'static str>,
+        /// Help message attached with [`help`](crate::parsers::NamedArg::help)
         help: Option<Doc>,
     },
 }
@@ -59,11 +84,16 @@ impl Item {
     }
 }
 
-#[doc(hidden)]
+/// Names a flag or an argument answers to
+///
+/// Names are stored without their dashes, `Long("file")` is written `--file` on a command line.
 #[derive(Copy, Clone, Debug)]
 pub enum ShortLong {
+    /// Only a short name, `-f`
     Short(char),
+    /// Only a long name, `--file`
     Long(&'static str),
+    /// Both, with the short name acting as an alias for the long one
     Both(char, &'static str),
 }
 

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,6 +1,16 @@
 use crate::{buffer::Doc, item::Item};
 
-#[doc(hidden)]
+/// Description of the shape of a parser
+///
+/// `Meta` is the tree `bpaf` builds to describe what a parser accepts: the combinators
+/// ([`And`](Meta::And), [`Or`](Meta::Or), [`Optional`](Meta::Optional), ...) form the branches
+/// and [`Item`] are the leaves of the tree.
+///
+/// Retrieve the tree with [`OptionParser::meta`](crate::OptionParser::meta) for a whole application or
+/// with [`Parser::meta`](crate::Parser::meta) for a fragment of one.
+///
+/// Parsers hidden with [`hide`](crate::Parser::hide) collapse into [`Skip`](Meta::Skip), so a
+/// hidden item is indistinguishable from an absent one.
 #[derive(Clone, Debug, Default)]
 pub enum Meta {
     /// All arguments listed in a vector must be present

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -36,7 +36,7 @@ pub enum Meta {
     /// This item is not rendered in the help message
     #[default]
     Skip,
-    /// TODO make it Option<Box<Doc>>
+    /// TODO make it `Option<Box<Doc>>`
     CustomUsage(Box<Meta>, Box<Doc>),
     /// this meta must be prefixed with -- in unsage group
     Strict(Box<Meta>),

--- a/src/meta_help.rs
+++ b/src/meta_help.rs
@@ -7,9 +7,19 @@ use crate::{
     Meta,
 };
 
-#[doc(hidden)]
+/// Placeholder shown in place of a value a parser consumes
+///
+/// `FILE` in `--config <FILE>`, stored without the surrounding angle brackets.
 #[derive(Debug, Clone, Copy)]
 pub struct Metavar(pub(crate) &'static str);
+
+impl Metavar {
+    /// Placeholder name, without the surrounding angle brackets
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        self.0
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum HelpItem<'a> {


### PR DESCRIPTION
Hi, 

I hope this contribution will be welcome! I need to create a custom renderer for the bpaf command-line; however, the internals are not exposed, so I submitted a PR to expose them.

I used a coding agent to understand what's needed and what needs to be exposed. I reviewed the comments and tweaked them a little bit.

Please let me know if this PR is acceptable! 

I tested these changes, and it seems that all the metadata needed for custom renderers are all in place.